### PR TITLE
Change 10.0KB into 10KB

### DIFF
--- a/bytes.go
+++ b/bytes.go
@@ -71,7 +71,7 @@ func humanateBytes(s uint64, base float64, sizes []string) string {
 	}
 	e := math.Floor(logn(float64(s), base))
 	suffix := sizes[int(e)]
-	val := math.Floor(float64(s) / math.Pow(base, math.Floor(e)) * 10 + 0.5) / 10 // correctly displays 9999B as 10KB and not 10.0KB
+	val := math.Floor(float64(s) / math.Pow(base, math.Floor(e)) * 10 + 0.5) / 10
 	f := "%.0f"
 	if val < 10 {
 		f = "%.1f"


### PR DESCRIPTION
When bytesize is 9999B for example, Bytes returns 10.0KB instead of the more visually appealing 10KB
