### PR TITLE
Allow custom defined time format.

### DIFF
--- a/times_test.go
+++ b/times_test.go
@@ -39,25 +39,27 @@ func TestPast(t *testing.T) {
 
 func TestFuture(t *testing.T) {
 	now := time.Now().Unix()
+	// add 1 second offset for test time to balance decimal fraction of time.Now()
+	offset := int64(time.Second)
 	testList{
 		{"now", Time(time.Unix(now, 0)), "now"},
-		{"1 second from now", Time(time.Unix(now+1, 0)), "1 second from now"},
-		{"12 seconds from now", Time(time.Unix(now+12, 0)), "12 seconds from now"},
-		{"30 seconds from now", Time(time.Unix(now+30, 0)), "30 seconds from now"},
-		{"45 seconds from now", Time(time.Unix(now+45, 0)), "45 seconds from now"},
-		{"15 minutes from now", Time(time.Unix(now+15*Minute, 0)), "15 minutes from now"},
-		{"2 hours from now", Time(time.Unix(now+2*Hour, 0)), "2 hours from now"},
-		{"21 hours from now", Time(time.Unix(now+21*Hour, 0)), "21 hours from now"},
-		{"1 day from now", Time(time.Unix(now+26*Hour, 0)), "1 day from now"},
-		{"2 days from now", Time(time.Unix(now+49*Hour, 0)), "2 days from now"},
-		{"3 days from now", Time(time.Unix(now+3*Day, 0)), "3 days from now"},
-		{"1 week from now (1)", Time(time.Unix(now+7*Day, 0)), "1 week from now"},
-		{"1 week from now (2)", Time(time.Unix(now+12*Day, 0)), "1 week from now"},
-		{"2 weeks from now", Time(time.Unix(now+15*Day, 0)), "2 weeks from now"},
-		{"1 month from now", Time(time.Unix(now+30*Day, 0)), "1 month from now"},
-		{"1 year from now", Time(time.Unix(now+365*Day, 0)), "1 year from now"},
-		{"2 years from now", Time(time.Unix(now+2*Year, 0)), "2 years from now"},
-		{"a while from now", Time(time.Unix(now+LongTime, 0)), "a long while from now"},
+		{"1 second from now", Time(time.Unix(now+1, offset)), "1 second from now"},
+		{"12 seconds from now", Time(time.Unix(now+12, offset)), "12 seconds from now"},
+		{"30 seconds from now", Time(time.Unix(now+30, offset)), "30 seconds from now"},
+		{"45 seconds from now", Time(time.Unix(now+45, offset)), "45 seconds from now"},
+		{"15 minutes from now", Time(time.Unix(now+15*Minute, offset)), "15 minutes from now"},
+		{"2 hours from now", Time(time.Unix(now+2*Hour, offset)), "2 hours from now"},
+		{"21 hours from now", Time(time.Unix(now+21*Hour, offset)), "21 hours from now"},
+		{"1 day from now", Time(time.Unix(now+26*Hour, offset)), "1 day from now"},
+		{"2 days from now", Time(time.Unix(now+49*Hour, offset)), "2 days from now"},
+		{"3 days from now", Time(time.Unix(now+3*Day, offset)), "3 days from now"},
+		{"1 week from now (1)", Time(time.Unix(now+7*Day, offset)), "1 week from now"},
+		{"1 week from now (2)", Time(time.Unix(now+12*Day, offset)), "1 week from now"},
+		{"2 weeks from now", Time(time.Unix(now+15*Day, offset)), "2 weeks from now"},
+		{"1 month from now", Time(time.Unix(now+30*Day, offset)), "1 month from now"},
+		{"1 year from now", Time(time.Unix(now+365*Day, offset)), "1 year from now"},
+		{"2 years from now", Time(time.Unix(now+2*Year, offset)), "2 years from now"},
+		{"a while from now", Time(time.Unix(now+LongTime, offset)), "a long while from now"},
 	}.validate(t)
 }
 
@@ -72,28 +74,29 @@ func TestRange(t *testing.T) {
 
 func TestRelTimeMagnitudes(t *testing.T) {
 	magnitudes := []Magnitude{
-		NewMagnitude(1, "now", 1),
-		NewMagnitude(2, "1s %s", 1),
-		NewMagnitude(Minute, "s %s", 1),
-		NewMagnitude(2*Minute, "1m %s", 1),
-		NewMagnitude(Hour, "%dm %s", Minute),
-		NewMagnitude(2*Hour, "1h %s", 1),
-		NewMagnitude(Day, "%dh %s", Hour),
-		NewMagnitude(2*Day, "1D %s", 1),
-		NewMagnitude(Month, "%dD %s", Day),
-		NewMagnitude(2*Month, "1M %s", 1),
-		NewMagnitude(Year, "%dM %s", Month),
-		NewMagnitude(18*Month, "1Y %s", 1),
-		NewMagnitude(2*Year, "2Y %s", 1),
+		NewMagnitude(1*time.Second, "now", time.Second),
+		NewMagnitude(2*time.Second, "1s %s", time.Second),
+		NewMagnitude(Minute*time.Second, "s %s", time.Second),
+		NewMagnitude(2*Minute*time.Second, "1m %s", time.Second),
+		NewMagnitude(Hour*time.Second, "%dm %s", Minute*time.Second),
+		NewMagnitude(2*Hour*time.Second, "1h %s", time.Second),
+		NewMagnitude(Day*time.Second, "%dh %s", Hour*time.Second),
+		NewMagnitude(2*Day*time.Second, "1D %s", time.Second),
+		NewMagnitude(Month*time.Second, "%dD %s", Day*time.Second),
+		NewMagnitude(2*Month*time.Second, "1M %s", time.Second),
+		NewMagnitude(Year*time.Second, "%dM %s", Month*time.Second),
+		NewMagnitude(18*Month*time.Second, "1Y %s", time.Second),
+		NewMagnitude(2*Year*time.Second, "2Y %s", time.Second),
 	}
 	now := time.Now().Unix()
+	timeNow := time.Unix(now, 0)
 	testList{
-		{"now", RelTimeMagnitudes(time.Unix(now, 0), time.Now(), "ago", "later", magnitudes), "now"},
-		{"1 second from now", RelTimeMagnitudes(time.Unix(now+1, 0), time.Now(), "ago", "later", magnitudes), "1s later"},
+		{"now", RelTimeMagnitudes(time.Unix(now, 0), timeNow, "ago", "later", magnitudes), "now"},
+		{"1 second from now", RelTimeMagnitudes(time.Unix(now+1, 1), timeNow, "ago", "later", magnitudes), "1s later"},
 		// Unit week has been removed from magnitudes
-		{"1 week ago", RelTimeMagnitudes(time.Unix(now-12*Day, 0), time.Now(), "ago", "", magnitudes), "12D ago"},
-		{"3 months ago", RelTimeMagnitudes(time.Unix(now-99*Day, 0), time.Now(), "ago", "later", magnitudes), "3M ago"},
-		{"1 year ago", RelTimeMagnitudes(time.Unix(now-365*Day, 0), time.Now(), "", "later", magnitudes), "1Y "},
-		{"out of defined magnitudes", RelTimeMagnitudes(time.Unix(now+LongTime, 0), time.Now(), "ago", "later", magnitudes), "undefined"},
+		{"1 week ago", RelTimeMagnitudes(time.Unix(now-12*Day, 0), timeNow, "ago", "", magnitudes), "12D ago"},
+		{"3 months ago", RelTimeMagnitudes(time.Unix(now-99*Day, 0), timeNow, "ago", "later", magnitudes), "3M ago"},
+		{"1 year ago", RelTimeMagnitudes(time.Unix(now-365*Day, 0), timeNow, "", "later", magnitudes), "1Y "},
+		{"out of defined magnitudes", RelTimeMagnitudes(time.Unix(now+LongTime, 0), timeNow, "ago", "later", magnitudes), "undefined"},
 	}.validate(t)
 }

--- a/times_test.go
+++ b/times_test.go
@@ -69,3 +69,31 @@ func TestRange(t *testing.T) {
 		t.Errorf("Expected a long while from now, got %q", x)
 	}
 }
+
+func TestRelTimeMagnitudes(t *testing.T) {
+	magnitudes := []Magnitude{
+		NewMagnitude(1, "now", 1),
+		NewMagnitude(2, "1s %s", 1),
+		NewMagnitude(Minute, "s %s", 1),
+		NewMagnitude(2*Minute, "1m %s", 1),
+		NewMagnitude(Hour, "%dm %s", Minute),
+		NewMagnitude(2*Hour, "1h %s", 1),
+		NewMagnitude(Day, "%dh %s", Hour),
+		NewMagnitude(2*Day, "1D %s", 1),
+		NewMagnitude(Month, "%dD %s", Day),
+		NewMagnitude(2*Month, "1M %s", 1),
+		NewMagnitude(Year, "%dM %s", Month),
+		NewMagnitude(18*Month, "1Y %s", 1),
+		NewMagnitude(2*Year, "2Y %s", 1),
+	}
+	now := time.Now().Unix()
+	testList{
+		{"now", RelTimeMagnitudes(time.Unix(now, 0), time.Now(), "ago", "later", magnitudes), "now"},
+		{"1 second from now", RelTimeMagnitudes(time.Unix(now+1, 0), time.Now(), "ago", "later", magnitudes), "1s later"},
+		// Unit week has been removed from magnitudes
+		{"1 week ago", RelTimeMagnitudes(time.Unix(now-12*Day, 0), time.Now(), "ago", "", magnitudes), "12D ago"},
+		{"3 months ago", RelTimeMagnitudes(time.Unix(now-99*Day, 0), time.Now(), "ago", "later", magnitudes), "3M ago"},
+		{"1 year ago", RelTimeMagnitudes(time.Unix(now-365*Day, 0), time.Now(), "", "later", magnitudes), "1Y "},
+		{"out of defined magnitudes", RelTimeMagnitudes(time.Unix(now+LongTime, 0), time.Now(), "ago", "later", magnitudes), "undefined"},
+	}.validate(t)
+}


### PR DESCRIPTION
Closes: #25

Add a new func to allow user to customize units and output format.

eg. Users can use something like '12s ago' or '21 days later' (skipped the 'week' unit).