### PR TITLE
I modified the time functions to be a bit more accurate.

### DIFF
--- a/times.go
+++ b/times.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"math"
 	"sort"
+	"strings"
 	"time"
 )
 
@@ -25,28 +26,83 @@ func Time(then time.Time) string {
 	return RelTime(then, time.Now(), "ago", "from now")
 }
 
+// AccurateTime formats a time into a relative string with a reasonable
+// level of accuracy.
+//
+// AccurateTime(someT) -> "3 weeks, 2 days, 11 hours ago"
+func AccurateTime(then time.Time) string {
+	return RelTimeMagnitudes(then, time.Now(), "ago", "from now", 2)
+}
+
 var magnitudes = []struct {
-	d      int64
-	format string
-	divby  int64
+	d        int64
+	format   string
+	doFormat bool
+	length   int64
 }{
-	{1, "now", 1},
-	{2, "1 second %s", 1},
-	{Minute, "%d seconds %s", 1},
-	{2 * Minute, "1 minute %s", 1},
-	{Hour, "%d minutes %s", Minute},
-	{2 * Hour, "1 hour %s", 1},
-	{Day, "%d hours %s", Hour},
-	{2 * Day, "1 day %s", 1},
-	{Week, "%d days %s", Day},
-	{2 * Week, "1 week %s", 1},
-	{Month, "%d weeks %s", Week},
-	{2 * Month, "1 month %s", 1},
-	{Year, "%d months %s", Month},
-	{18 * Month, "1 year %s", 1},
-	{2 * Year, "2 years %s", 1},
-	{LongTime, "%d years %s", Year},
-	{math.MaxInt64, "a long while %s", 1},
+	//{1, "now", false, 1},
+	{2, "1 second", false, 1},
+	{Minute, "%d seconds", true, 1},
+	{2 * Minute, "1 minute", false, Minute},
+	{Hour, "%d minutes", true, Minute},
+	{2 * Hour, "1 hour", false, Hour},
+	{Day, "%d hours", true, Hour},
+	{2 * Day, "1 day", false, Day},
+	{Week, "%d days", true, Day},
+	{2 * Week, "1 week", false, Week},
+	{Month, "%d weeks", true, Week},
+	{2 * Month, "1 month", false, Month},
+	{Year, "%d months", true, Month},
+	{2 * Year, "1 year", false, Year},
+	{LongTime, "%d years", true, Year},
+	{math.MaxInt64, "a long while", false, 1},
+}
+
+// RelTimeMagnitudes formats a time into a relative string.
+//
+// It takes two times and two labels and a magnitude.  In addition to
+// the generic time delta string (e.g. 5 minutes), the labels are
+// used applied so that the label corresponding to the smaller time is
+// applied.
+//
+// The magnitude determines how accurate the time should be, a magnitude
+// of 2 will return strings like "2 years, 8 months ago", 3 will return
+// "2 years, 8 months, 1 week ago", etc.
+//
+// RelTimeMagnitude(timeInPast, timeInFuture, "earlier", "later", 2) -> "3 weeks, 2 days earlier"
+func RelTimeMagnitudes(a, b time.Time, albl, blbl string, numMagnitudes int) string {
+	lbl := albl
+	diff := b.Unix() - a.Unix()
+
+	after := a.After(b)
+	if after {
+		lbl = blbl
+		diff = a.Unix() - b.Unix()
+	}
+
+	if diff == 0 {
+		return "now"
+	}
+
+	strs := []string{}
+	for i := 0; i < numMagnitudes; i++ {
+		n := sort.Search(len(magnitudes), func(idx int) bool {
+			return magnitudes[idx].d > diff
+		})
+
+		if magnitudes[n].doFormat {
+			strs = append(strs, fmt.Sprintf(magnitudes[n].format, diff/magnitudes[n].length))
+		} else {
+			strs = append(strs, magnitudes[n].format)
+		}
+
+		diff -= magnitudes[n].length * (diff / magnitudes[n].length)
+		if diff <= 0 {
+			break
+		}
+	}
+
+	return fmt.Sprintf("%s %s", strings.Join(strs, ", "), lbl)
 }
 
 // RelTime formats a time into a relative string.
@@ -57,35 +113,5 @@ var magnitudes = []struct {
 //
 // RelTime(timeInPast, timeInFuture, "earlier", "later") -> "3 weeks earlier"
 func RelTime(a, b time.Time, albl, blbl string) string {
-	lbl := albl
-	diff := b.Unix() - a.Unix()
-
-	after := a.After(b)
-	if after {
-		lbl = blbl
-		diff = a.Unix() - b.Unix()
-	}
-
-	n := sort.Search(len(magnitudes), func(i int) bool {
-		return magnitudes[i].d > diff
-	})
-
-	mag := magnitudes[n]
-	args := []interface{}{}
-	escaped := false
-	for _, ch := range mag.format {
-		if escaped {
-			switch ch {
-			case '%':
-			case 's':
-				args = append(args, lbl)
-			case 'd':
-				args = append(args, diff/mag.divby)
-			}
-			escaped = false
-		} else {
-			escaped = ch == '%'
-		}
-	}
-	return fmt.Sprintf(mag.format, args...)
+	return RelTimeMagnitudes(a, b, albl, blbl, 1)
 }

--- a/times_test.go
+++ b/times_test.go
@@ -6,6 +6,68 @@ import (
 	"time"
 )
 
+func TestPastAccurate(t *testing.T) {
+	now := time.Now()
+	testList{
+		{
+			"1 minute, 30 seconds ago",
+			AccurateTime(now.Add(-1 * time.Minute).Add(-30 * time.Second)),
+			"1 minute, 30 seconds ago",
+		},
+		{
+			"1 hour, 30 minutes ago (1)",
+			AccurateTime(now.Add(-1 * time.Hour).Add(-30 * time.Minute)),
+			"1 hour, 30 minutes ago",
+		},
+		{ // Discard extra time
+			"1 hour, 30 minutes ago (2)",
+			AccurateTime(now.Add(-1 * time.Hour).Add(-30 * time.Minute).Add(-30 * time.Second)),
+			"1 hour, 30 minutes ago",
+		},
+		{
+			"2 hours, 30 minutes ago (1)",
+			AccurateTime(now.Add(-2 * time.Hour).Add(-30 * time.Minute)),
+			"2 hours, 30 minutes ago",
+		},
+		{ // Discard extra time
+			"2 hours, 30 minutes ago (2)",
+			AccurateTime(now.Add(-2 * time.Hour).Add(-30 * time.Minute).Add(-30 * time.Second)),
+			"2 hours, 30 minutes ago",
+		},
+	}.validate(t)
+}
+
+func TestFutureAccurate(t *testing.T) {
+	now := time.Now()
+	testList{
+		{
+			"1 minute, 30 seconds from now",
+			AccurateTime(now.Add(1 * time.Minute).Add(30 * time.Second)),
+			"1 minute, 30 seconds from now",
+		},
+		{
+			"1 hour, 30 minutes from now (1)",
+			AccurateTime(now.Add(1 * time.Hour).Add(30 * time.Minute)),
+			"1 hour, 30 minutes from now",
+		},
+		{ // Discard extra time
+			"1 hour, 30 minutes from now (2)",
+			AccurateTime(now.Add(1 * time.Hour).Add(30 * time.Minute).Add(30 * time.Second)),
+			"1 hour, 30 minutes from now",
+		},
+		{
+			"2 hours, 30 minutes from now (1)",
+			AccurateTime(now.Add(2 * time.Hour).Add(30 * time.Minute)),
+			"2 hours, 30 minutes from now",
+		},
+		{ // Discard extra time
+			"2 hours, 30 minutes from now (2)",
+			AccurateTime(now.Add(2 * time.Hour).Add(30 * time.Minute).Add(30 * time.Second)),
+			"2 hours, 30 minutes from now",
+		},
+	}.validate(t)
+}
+
 func TestPast(t *testing.T) {
 	now := time.Now().Unix()
 	testList{


### PR DESCRIPTION
Added an AccurateTime function that returns strings like 2 years, 8 months.

Added a RelTimeMagnitude that implements this with configurable number of descending magnitudes.

Broke some fuzzy time in the 1 Year and higher range.  This one confused me a bit, I'm not sure what the intent was but it didn't make any sense to me.

I also cleaned up the RelTime function, taking that loop that iterated over the format string trying to build an argument list.  It was kind of convoluted and as every case was exactly the same after I removed the %s from each (adding the "ago" later) so I just added a flag and a single parameter to Sprintf.

I made "now" a special case because it was simpler to do that.

I think I left a broken test or two in your tests, having to do with the fuzzy "years" ranges.  Didn't know what to do about that and my tests could certainly be more comprehensive.