### PR TITLE
Add space between numbers and units in README, package documentation.

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -3,7 +3,7 @@
 Just a few functions for helping humanize times and sizes.
 
 `go get` it as `github.com/dustin/go-humanize`, import it as
-`"github.com/dustin/go-humanize"`, use it as `humanize`
+`"github.com/dustin/go-humanize"`, use it as `humanize`.
 
 See [godoc](https://godoc.org/github.com/dustin/go-humanize) for
 complete documentation.
@@ -11,12 +11,12 @@ complete documentation.
 ## Sizes
 
 This lets you take numbers like `82854982` and convert them to useful
-strings like, `83MB` or `79MiB` (whichever you prefer).
+strings like, `83 MB` or `79 MiB` (whichever you prefer).
 
 Example:
 
 ```go
-fmt.Printf("That file is %s.", humanize.Bytes(82854982))
+fmt.Printf("That file is %s.", humanize.Bytes(82854982)) // That file is 83 MB.
 ```
 
 ## Times
@@ -27,11 +27,11 @@ For example, `12 seconds ago` or `3 days from now`.
 Example:
 
 ```go
-fmt.Printf("This was touched %s", humanize.Time(someTimeInstance))
+fmt.Printf("This was touched %s.", humanize.Time(someTimeInstance)) // This was touched 7 hours ago.
 ```
 
 Thanks to Kyle Lemons for the time implementation from an IRC
-conversation one day.  It's pretty neat.
+conversation one day. It's pretty neat.
 
 ## Ordinals
 
@@ -48,12 +48,12 @@ to label ordinals.
 Example:
 
 ```go
-fmt.Printf("You're my %s best friend.", humanize.Ordinal(193))
+fmt.Printf("You're my %s best friend.", humanize.Ordinal(193)) // You are my 193rd best friend.
 ```
 
 ## Commas
 
-Want to shove commas into numbers?  Be my guest.
+Want to shove commas into numbers? Be my guest.
 
     0 -> 0
     100 -> 100
@@ -64,7 +64,7 @@ Want to shove commas into numbers?  Be my guest.
 Example:
 
 ```go
-fmt.Printf("You owe $%s.\n", humanize.Comma(6582491))
+fmt.Printf("You owe $%s.\n", humanize.Comma(6582491)) // You owe $6,582,491.
 ```
 
 ## Ftoa
@@ -72,10 +72,10 @@ fmt.Printf("You owe $%s.\n", humanize.Comma(6582491))
 Nicer float64 formatter that removes trailing zeros.
 
 ```go
-fmt.Printf("%f", 2.24)                   // 2.240000
-fmt.Printf("%s", humanize.Ftoa(2.24))    // 2.24
-fmt.Printf("%f", 2.0)                    // 2.000000
-fmt.Printf("%s", humanize.Ftoa(2.0))     // 2
+fmt.Printf("%f", 2.24)                // 2.240000
+fmt.Printf("%s", humanize.Ftoa(2.24)) // 2.24
+fmt.Printf("%f", 2.0)                 // 2.000000
+fmt.Printf("%s", humanize.Ftoa(2.0))  // 2
 ```
 
 ## SI notation
@@ -85,7 +85,7 @@ Format numbers with [SI notation][sinotation].
 Example:
 
 ```go
-humanize.SI(0.00000000223, "M")    // 2.23nM
+humanize.SI(0.00000000223, "M") // 2.23 nM
 ```
 
 [odisc]: https://groups.google.com/d/topic/golang-nuts/l8NhI74jl-4/discussion

--- a/bigbytes.go
+++ b/bigbytes.go
@@ -113,7 +113,7 @@ func humanateBigBytes(s, base *big.Int, sizes []string) string {
 //
 // See also: ParseBigBytes.
 //
-// BigBytes(82854982) -> 83MB
+// BigBytes(82854982) -> 83 MB
 func BigBytes(s *big.Int) string {
 	sizes := []string{"B", "kB", "MB", "GB", "TB", "PB", "EB", "ZB", "YB"}
 	return humanateBigBytes(s, bigSIExp, sizes)
@@ -123,7 +123,7 @@ func BigBytes(s *big.Int) string {
 //
 // See also: ParseBigBytes.
 //
-// BigIBytes(82854982) -> 79MiB
+// BigIBytes(82854982) -> 79 MiB
 func BigIBytes(s *big.Int) string {
 	sizes := []string{"B", "KiB", "MiB", "GiB", "TiB", "PiB", "EiB", "ZiB", "YiB"}
 	return humanateBigBytes(s, bigIECExp, sizes)
@@ -134,8 +134,8 @@ func BigIBytes(s *big.Int) string {
 //
 // See also: BigBytes, BigIBytes.
 //
-// ParseBigBytes("42MB") -> 42000000, nil
-// ParseBigBytes("42mib") -> 44040192, nil
+// ParseBigBytes("42 MB") -> 42000000, nil
+// ParseBigBytes("42 mib") -> 44040192, nil
 func ParseBigBytes(s string) (*big.Int, error) {
 	lastDigit := 0
 	hasComma := false

--- a/bytes.go
+++ b/bytes.go
@@ -84,7 +84,7 @@ func humanateBytes(s uint64, base float64, sizes []string) string {
 //
 // See also: ParseBytes.
 //
-// Bytes(82854982) -> 83MB
+// Bytes(82854982) -> 83 MB
 func Bytes(s uint64) string {
 	sizes := []string{"B", "kB", "MB", "GB", "TB", "PB", "EB"}
 	return humanateBytes(s, 1000, sizes)
@@ -94,7 +94,7 @@ func Bytes(s uint64) string {
 //
 // See also: ParseBytes.
 //
-// IBytes(82854982) -> 79MiB
+// IBytes(82854982) -> 79 MiB
 func IBytes(s uint64) string {
 	sizes := []string{"B", "KiB", "MiB", "GiB", "TiB", "PiB", "EiB"}
 	return humanateBytes(s, 1024, sizes)
@@ -105,8 +105,8 @@ func IBytes(s uint64) string {
 //
 // See Also: Bytes, IBytes.
 //
-// ParseBytes("42MB") -> 42000000, nil
-// ParseBytes("42mib") -> 44040192, nil
+// ParseBytes("42 MB") -> 42000000, nil
+// ParseBytes("42 mib") -> 44040192, nil
 func ParseBytes(s string) (uint64, error) {
 	lastDigit := 0
 	hasComma := false

--- a/humanize.go
+++ b/humanize.go
@@ -2,7 +2,7 @@
 Package humanize converts boring ugly numbers to human-friendly strings and back.
 
 Durations can be turned into strings such as "3 days ago", numbers
-representing sizes like 82854982 into useful strings like, "83MB" or
-"79MiB" (whichever you prefer).
+representing sizes like 82854982 into useful strings like, "83 MB" or
+"79 MiB" (whichever you prefer).
 */
 package humanize

--- a/si.go
+++ b/si.go
@@ -68,7 +68,7 @@ func ComputeSI(input float64) (float64, string) {
 	value := mag / math.Pow(10, exponent)
 
 	// Handle special case where value is exactly 1000.0
-	// Should return 1M instead of 1000k
+	// Should return 1 M instead of 1000 k
 	if value == 1000.0 {
 		exponent += 3
 		value = mag / math.Pow(10, exponent)
@@ -86,8 +86,8 @@ func ComputeSI(input float64) (float64, string) {
 //
 // See also: ComputeSI, ParseSI.
 //
-// e.g. SI(1000000, B) -> 1MB
-// e.g. SI(2.2345e-12, "F") -> 2.2345pF
+// e.g. SI(1000000, "B") -> 1 MB
+// e.g. SI(2.2345e-12, "F") -> 2.2345 pF
 func SI(input float64, unit string) string {
 	value, prefix := ComputeSI(input)
 	return Ftoa(value) + " " + prefix + unit
@@ -99,7 +99,7 @@ var errInvalid = errors.New("invalid input")
 //
 // See also: SI, ComputeSI.
 //
-// e.g. ParseSI(2.2345pF) -> (2.2345e-12, "F", nil)
+// e.g. ParseSI("2.2345 pF") -> (2.2345e-12, "F", nil)
 func ParseSI(input string) (float64, string, error) {
 	found := riParseRegex.FindStringSubmatch(input)
 	if len(found) != 4 {


### PR DESCRIPTION
When we added space between numbers and units in 64dbdae0d393b7d71480a6dace78456396b55286, the README and package documentation weren't updated. This fixes that.

Also fix various other minor issues in documentation that I found. Use single space between sentences in README, to follow Go style (see https://dmitri.shuralyov.com/idiomatic-go#single-spaces-between-sentences).

Follows 64dbdae0d393b7d71480a6dace78456396b55286.
Helps #21.