### PR TITLE
ParseSI: honor exponent notation

### DIFF
--- a/si.go
+++ b/si.go
@@ -49,7 +49,7 @@ func revfmap(in map[float64]string, aliases map[string]string) map[string]float6
 var riParseRegex *regexp.Regexp
 
 func init() {
-	ri := `^([\-0-9.]+)\s?([`
+	ri := `^([\-0-9.eE]+)\s?([`
 	for k := range revSIPrefixTable {
 		ri += k
 	}

--- a/si.go
+++ b/si.go
@@ -27,13 +27,21 @@ var siPrefixTable = map[float64]string{
 	24:  "Y", // yotta
 }
 
-var revSIPrefixTable = revfmap(siPrefixTable)
+var siPrefixAliasTable = map[string]string{
+	"K": "k",
+	"u": "µ",
+}
+
+var revSIPrefixTable = revfmap(siPrefixTable, siPrefixAliasTable)
 
 // revfmap reverses the map and precomputes the power multiplier
-func revfmap(in map[float64]string) map[string]float64 {
+func revfmap(in map[float64]string, aliases map[string]string) map[string]float64 {
 	rv := map[string]float64{}
 	for k, v := range in {
 		rv[v] = math.Pow(10, k)
+	}
+	for alt, real := range aliases {
+		rv[alt] = rv[real]
 	}
 	return rv
 }
@@ -42,8 +50,8 @@ var riParseRegex *regexp.Regexp
 
 func init() {
 	ri := `^([\-0-9.]+)\s?([`
-	for _, v := range siPrefixTable {
-		ri += v
+	for k := range revSIPrefixTable {
+		ri += k
 	}
 	ri += `]?)(.*)`
 

--- a/si_test.go
+++ b/si_test.go
@@ -87,10 +87,37 @@ func TestSI(t *testing.T) {
 		}
 	}
 
-	// Parse error
-	gotf, gotu, err := ParseSI("x1.21JW") // 1.21 jigga whats
-	if err == nil {
-		t.Errorf("Expected error on x1.21JW, got %v %v", gotf, gotu)
+}
+
+func TestParseSI(t *testing.T) {
+	tests := []struct {
+		input    string
+		num      float64
+		unit     string
+		hasError bool
+	}{
+		{"1.21kW", 1210.0, "W", false},
+		{"1.21 kW", 1210.0, "W", false},
+		{"1.21 KW", 1210.0, "W", false},
+		{"1.21µW", 1.21e-6, "W", false},
+		{"1.21uW", 1.21e-6, "W", false},
+		{"1.21 uW", 1.21e-6, "W", false},
+		{"x1.21JW", 0, "", true},
+	}
+
+	for _, test := range tests {
+		gotf, gotu, err := ParseSI(test.input)
+		if test.hasError && err == nil {
+			t.Errorf("Expected error on %s, got %v %v", test.input, gotf, gotu)
+		}
+		if math.Abs(1-(gotf/test.num)) > 0.01 {
+			t.Errorf("On %v got %v, wanted %v (±%v)",
+				test.input, gotf, test.num,
+				math.Abs(1-(gotf/test.num)))
+		}
+		if gotu != test.unit {
+			t.Errorf("On %v expected %v got %v", test.input, test.unit, gotu)
+		}
 	}
 }
 

--- a/si_test.go
+++ b/si_test.go
@@ -102,6 +102,17 @@ func TestParseSI(t *testing.T) {
 		{"1.21µW", 1.21e-6, "W", false},
 		{"1.21uW", 1.21e-6, "W", false},
 		{"1.21 uW", 1.21e-6, "W", false},
+		{"6.8e-3 W", 6.8e-3, "W", false},
+		{"6.8E-3 W", 6.8e-3, "W", false},
+		{"6.8e-3W", 6.8e-3, "W", false},
+		{"-6.8e-3W", -6.8e-3, "W", false},
+		{"-6.8e-3 W", -6.8e-3, "W", false},
+		{"-6.8e-3 kW", -6.8, "W", false},
+		{"1000", 1000, "", false},
+		{"1000W", 1000, "W", false},
+		{"0W", 0, "W", false},
+		{"0.6 pF", 6e-13, "F", false},
+		{"100pF", 1e-10, "F", false},
 		{"x1.21JW", 0, "", true},
 	}
 
@@ -109,6 +120,9 @@ func TestParseSI(t *testing.T) {
 		gotf, gotu, err := ParseSI(test.input)
 		if test.hasError && err == nil {
 			t.Errorf("Expected error on %s, got %v %v", test.input, gotf, gotu)
+		}
+		if !test.hasError && err != nil {
+			t.Errorf("Expected no error on %s, got error %v", test.input, err)
 		}
 		if math.Abs(1-(gotf/test.num)) > 0.01 {
 			t.Errorf("On %v got %v, wanted %v (±%v)",


### PR DESCRIPTION
This PR adds on to https://github.com/dustin/go-humanize/pull/53.

* Handles inputs that already have exponents like: 6.8E-3 W