### PR TITLE
Updated .travis.yml to use the latest Go releases

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,12 @@
 sudo: false
 language: go
 go:
-  - 1.3.3
-  - 1.5.4
-  - 1.6.2
+  - 1.3
+  - 1.5
+  - 1.6
+  - 1.7
+  - 1.8
+  - 1.9
   - tip
 matrix:
   allow_failures:


### PR DESCRIPTION
Specifically use the latest versions of 1.3/1.5/1.6, and to now additionally test with Go 1.7-1.9.