### PR TITLE
Travis: Use latest patch versions.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,16 +1,16 @@
 sudo: false
 language: go
 go:
-  - 1.3
-  - 1.5
-  - 1.6
-  - 1.7
-  - 1.8
-  - 1.9
-  - tip
+  - 1.3.x
+  - 1.5.x
+  - 1.6.x
+  - 1.7.x
+  - 1.8.x
+  - 1.9.x
+  - master
 matrix:
   allow_failures:
-    - go: tip
+    - go: master
   fast_finish: true
 install:
   - # Do nothing. This is needed to prevent default install action "go get -t -v ./..." from happening here (we want it to happen inside script step).


### PR DESCRIPTION
Also rename `tip` to `master`, since that's how Travis refers to it now.

Reference: https://docs.travis-ci.com/user/languages/go/#Specifying-a-Go-version-to-use.

/cc @bramp