### PR TITLE
Fix off by one error in RelTime

### DIFF
--- a/times.go
+++ b/times.go
@@ -91,7 +91,7 @@ func CustomRelTime(a, b time.Time, albl, blbl string, magnitudes []RelTimeMagnit
 	}
 
 	n := sort.Search(len(magnitudes), func(i int) bool {
-		return magnitudes[i].D >= diff
+		return magnitudes[i].D > diff
 	})
 
 	if n >= len(magnitudes) {

--- a/times_test.go
+++ b/times_test.go
@@ -37,6 +37,17 @@ func TestPast(t *testing.T) {
 	}.validate(t)
 }
 
+func TestReltimeOffbyone(t *testing.T) {
+	testList{
+		{"1w-1", RelTime(time.Unix(0, 0), time.Unix(7*24*60*60, -1), "ago", ""), "6 days ago"},
+		{"1w±0", RelTime(time.Unix(0, 0), time.Unix(7*24*60*60, 0), "ago", ""), "1 week ago"},
+		{"1w+1", RelTime(time.Unix(0, 0), time.Unix(7*24*60*60, 1), "ago", ""), "1 week ago"},
+		{"2w-1", RelTime(time.Unix(0, 0), time.Unix(14*24*60*60, -1), "ago", ""), "1 week ago"},
+		{"2w±0", RelTime(time.Unix(0, 0), time.Unix(14*24*60*60, 0), "ago", ""), "2 weeks ago"},
+		{"2w+1", RelTime(time.Unix(0, 0), time.Unix(14*24*60*60, 1), "ago", ""), "2 weeks ago"},
+	}.validate(t)
+}
+
 func TestFuture(t *testing.T) {
 	// Add a little time so that these things properly line up in
 	// the future.


### PR DESCRIPTION
This change fixes a user reported issue where the `RelTime` formatter picks the wrong magnitude at the exact nanosecond it changes.

User report:

```
package main

import (
	"fmt"
	"time"

	"google3/base/go/google"
	"google3/third_party/golang/humanize/humanize"
)

func main() {
	google.Init()
	fmt.Println(humanize.RelTime(time.Unix(0, 0), time.Unix(7*24*60*60, 0), "ago", ""))
	fmt.Println(humanize.RelTime(time.Unix(0, 0), time.Unix(7*24*60*60, 1), "ago", ""))
	fmt.Println(humanize.RelTime(time.Unix(0, 0), time.Unix(14*24*60*60, 0), "ago", ""))
	fmt.Println(humanize.RelTime(time.Unix(0, 0), time.Unix(14*24*60*60, 1), "ago", ""))
}
```

produces the following output:

```
7 days ago
1 week ago
1 week ago
2 weeks ago
```