### PR TITLE
handle -es plurals better

### DIFF
--- a/english/words.go
+++ b/english/words.go
@@ -15,7 +15,7 @@ var specialPlurals = map[string]string{
 	"vertex": "vertices",
 }
 
-var sibilantEndings = []string{"s", "sh", "tch", "x"}
+var sibilantEndings = []string{"ch", "s", "sh", "x", "z"}
 
 var isVowel = map[byte]bool{
 	'A': true, 'E': true, 'I': true, 'O': true, 'U': true,

--- a/english/words_test.go
+++ b/english/words_test.go
@@ -23,7 +23,9 @@ func TestPluralWord(t *testing.T) {
 		{2, "bus", "", "buses"},
 		{2, "bush", "", "bushes"},
 		{2, "watch", "", "watches"},
+		{2, "church", "", "churches"},
 		{2, "box", "", "boxes"},
+		{2, "waltz", "", "waltzes"},
 
 		// ending with 'o' preceded by a consonant
 		{2, "hero", "", "heroes"},


### PR DESCRIPTION
"tch" is a bit restrictive and should probably just be "ch".  e.g. "march", "coach", "finch", "bench", "punch", and "beach".  The few exceptions to the more general rule are "epoch" and "loch".