### PR TITLE
Renew godoc url in README

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -5,7 +5,7 @@ Just a few functions for helping humanize times and sizes.
 `go get` it as `github.com/dustin/go-humanize`, import it as
 `"github.com/dustin/go-humanize"`, use it as `humanize`.
 
-See [godoc](https://godoc.org/github.com/dustin/go-humanize) for
+See [godoc](https://pkg.go.dev/github.com/dustin/go-humanize) for
 complete documentation.
 
 ## Sizes


### PR DESCRIPTION
Renew it to pkg.go.dev from godoc.org .

and you should change the URL in the repository description.