### PR TITLE
Add go.mod

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,12 @@
 sudo: false
 language: go
+go_import_path: github.com/dustin/go-humanize
 go:
-  - 1.3.x
-  - 1.5.x
-  - 1.6.x
-  - 1.7.x
-  - 1.8.x
-  - 1.9.x
+  - 1.13.x
+  - 1.14.x
+  - 1.15.x
+  - 1.16.x
+  - stable
   - master
 matrix:
   allow_failures:
@@ -15,7 +15,7 @@ matrix:
 install:
   - # Do nothing. This is needed to prevent default install action "go get -t -v ./..." from happening here (we want it to happen inside script step).
 script:
-  - go get -t -v ./...
   - diff -u <(echo -n) <(gofmt -d -s .)
-  - go tool vet .
+  - go vet .
+  - go install -v -race ./...
   - go test -v -race ./...

--- a/commaf.go
+++ b/commaf.go
@@ -1,3 +1,4 @@
+//go:build go1.6
 // +build go1.6
 
 package humanize

--- a/commaf_test.go
+++ b/commaf_test.go
@@ -1,3 +1,4 @@
+//go:build go1.6
 // +build go1.6
 
 package humanize

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module github.com/dustin/go-humanize
+
+go 1.16


### PR DESCRIPTION
Converting this package to Go modules makes it easier to use module proxies, etc.

Additionally, bump Go versions in Travis CI configuration.