### PR TITLE
Fix staticcheck errors

### DIFF
--- a/bigbytes_test.go
+++ b/bigbytes_test.go
@@ -66,7 +66,7 @@ func TestBigByteErrors(t *testing.T) {
 	if err == nil {
 		t.Errorf("Expected error, got %v", got)
 	}
-	got, err = ParseBigBytes("")
+	_, err = ParseBigBytes("")
 	if err == nil {
 		t.Errorf("Expected error parsing nothing")
 	}

--- a/bytes_test.go
+++ b/bytes_test.go
@@ -65,7 +65,7 @@ func TestByteErrors(t *testing.T) {
 	if err == nil {
 		t.Errorf("Expected error, got %v", got)
 	}
-	got, err = ParseBytes("")
+	_, err = ParseBytes("")
 	if err == nil {
 		t.Errorf("Expected error parsing nothing")
 	}

--- a/number.go
+++ b/number.go
@@ -73,7 +73,7 @@ func FormatFloat(format string, n float64) string {
 	if n > math.MaxFloat64 {
 		return "Infinity"
 	}
-	if n < -math.MaxFloat64 {
+	if n < (0.0 - math.MaxFloat64) {
 		return "-Infinity"
 	}
 


### PR DESCRIPTION
Fixed the following errors:

	bigbytes_test.go:69:2: this value of got is never used (SA4006)
	bytes_test.go:68:2: this value of got is never used (SA4006)
	number.go:76:9: constant  overflow (compile)