### PR TITLE
Comma() is 2.5 faster now

### DIFF
--- a/comma.go
+++ b/comma.go
@@ -13,6 +13,7 @@ import (
 //
 // e.g. Comma(834142) -> 834,142
 func Comma(v int64) string {
+	// Shortcut for [0, 7]
 	if v&^0b111 == 0 {
 		return string([]byte{byte(v) + 48})
 	}

--- a/comma.go
+++ b/comma.go
@@ -33,24 +33,24 @@ func Comma(v int64) string {
 		count++
 	}
 	output := make([]byte, count)
-	currentIndex := byte(len(output) - 1)
+	j := len(output) - 1
 
 	var counter byte = 0
 	for v > 9 {
-		output[currentIndex] = byte(v%10) + 48
+		output[j] = byte(v%10) + 48
 		v = v / 10
-		currentIndex--
+		j--
 		if counter == 2 {
 			counter = 0
-			output[currentIndex] = ','
-			currentIndex--
+			output[j] = ','
+			j--
 		} else {
 			counter++
 		}
 	}
 
-	output[currentIndex] = byte(v) + 48
-	if currentIndex == 1 {
+	output[j] = byte(v) + 48
+	if j == 1 {
 		output[0] = '-'
 	}
 	return string(output)

--- a/comma.go
+++ b/comma.go
@@ -13,34 +13,47 @@ import (
 //
 // e.g. Comma(834142) -> 834,142
 func Comma(v int64) string {
-	sign := ""
+	if v&^0b111 == 0 {
+		return string([]byte{byte(v) + 48})
+	}
 
 	// Min int64 can't be negated to a usable value, so it has to be special cased.
 	if v == math.MinInt64 {
 		return "-9,223,372,036,854,775,808"
 	}
+	// Counting the number of digits.
+	var count byte = 0
+	for n := v; n != 0; n = n / 10 {
+		count++
+	}
 
+	count += (count - 1) / 3
 	if v < 0 {
-		sign = "-"
 		v = 0 - v
+		count++
 	}
+	output := make([]byte, count)
+	currentIndex := byte(len(output) - 1)
 
-	parts := []string{"", "", "", "", "", "", ""}
-	j := len(parts) - 1
-
-	for v > 999 {
-		parts[j] = strconv.FormatInt(v%1000, 10)
-		switch len(parts[j]) {
-		case 2:
-			parts[j] = "0" + parts[j]
-		case 1:
-			parts[j] = "00" + parts[j]
+	var counter byte = 0
+	for v > 9 {
+		output[currentIndex] = byte(v%10) + 48
+		v = v / 10
+		currentIndex--
+		if counter == 2 {
+			counter = 0
+			output[currentIndex] = ','
+			currentIndex--
+		} else {
+			counter++
 		}
-		v = v / 1000
-		j--
 	}
-	parts[j] = strconv.Itoa(int(v))
-	return sign + strings.Join(parts[j:], ",")
+
+	output[currentIndex] = byte(v) + 48
+	if currentIndex == 1 {
+		output[0] = '-'
+	}
+	return string(output)
 }
 
 // Commaf produces a string form of the given number in base 10 with


### PR DESCRIPTION
Hi there!

Decided to leetcode `Comma()`. The result is in this PR. Managed to get rid of 4 allocations, removed 2 dependencies and reduced the execution time.

```
goos: darwin
goarch: arm64
pkg: github.com/kaatinga/krendel
BenchmarkComma
BenchmarkComma-8          	 5709186	       207.5 ns/op	      50 B/op	       8 allocs/op
BenchmarkInt64_String
BenchmarkInt64_String-8   	13717701	        86.55 ns/op	      64 B/op	       4 allocs/op
PASS
```