### PR TITLE
Add new SI and IEC prefixes: ronto, quecto, ronna, quetta

### DIFF
--- a/bigbytes.go
+++ b/bigbytes.go
@@ -28,6 +28,10 @@ var (
 	BigZiByte = (&big.Int{}).Mul(BigEiByte, bigIECExp)
 	// BigYiByte is 1,024 z bytes in bit.Ints
 	BigYiByte = (&big.Int{}).Mul(BigZiByte, bigIECExp)
+	// BigRiByte is 1,024 y bytes in bit.Ints
+	BigRiByte = (&big.Int{}).Mul(BigYiByte, bigIECExp)
+	// BigQiByte is 1,024 r bytes in bit.Ints
+	BigQiByte = (&big.Int{}).Mul(BigRiByte, bigIECExp)
 )
 
 var (
@@ -51,6 +55,10 @@ var (
 	BigZByte = (&big.Int{}).Mul(BigEByte, bigSIExp)
 	// BigYByte is 1,000 SI z bytes in big.Ints
 	BigYByte = (&big.Int{}).Mul(BigZByte, bigSIExp)
+	// BigRByte is 1,000 SI y bytes in big.Ints
+	BigRByte = (&big.Int{}).Mul(BigYByte, bigSIExp)
+	// BigQByte is 1,000 SI r bytes in big.Ints
+	BigQByte = (&big.Int{}).Mul(BigRByte, bigSIExp)
 )
 
 var bigBytesSizeTable = map[string]*big.Int{
@@ -71,6 +79,10 @@ var bigBytesSizeTable = map[string]*big.Int{
 	"zb":  BigZByte,
 	"yib": BigYiByte,
 	"yb":  BigYByte,
+	"rib": BigRiByte,
+	"rb":  BigRByte,
+	"qib": BigQiByte,
+	"qb":  BigQByte,
 	// Without suffix
 	"":   BigByte,
 	"ki": BigKiByte,
@@ -89,6 +101,10 @@ var bigBytesSizeTable = map[string]*big.Int{
 	"zi": BigZiByte,
 	"y":  BigYByte,
 	"yi": BigYiByte,
+	"r":  BigRByte,
+	"ri": BigRiByte,
+	"q":  BigQByte,
+	"qi": BigQiByte,
 }
 
 var ten = big.NewInt(10)
@@ -115,7 +131,7 @@ func humanateBigBytes(s, base *big.Int, sizes []string) string {
 //
 // BigBytes(82854982) -> 83 MB
 func BigBytes(s *big.Int) string {
-	sizes := []string{"B", "kB", "MB", "GB", "TB", "PB", "EB", "ZB", "YB"}
+	sizes := []string{"B", "kB", "MB", "GB", "TB", "PB", "EB", "ZB", "YB", "RB", "QB"}
 	return humanateBigBytes(s, bigSIExp, sizes)
 }
 
@@ -125,7 +141,7 @@ func BigBytes(s *big.Int) string {
 //
 // BigIBytes(82854982) -> 79 MiB
 func BigIBytes(s *big.Int) string {
-	sizes := []string{"B", "KiB", "MiB", "GiB", "TiB", "PiB", "EiB", "ZiB", "YiB"}
+	sizes := []string{"B", "KiB", "MiB", "GiB", "TiB", "PiB", "EiB", "ZiB", "YiB", "RiB", "QiB"}
 	return humanateBigBytes(s, bigIECExp, sizes)
 }
 

--- a/si.go
+++ b/si.go
@@ -8,6 +8,8 @@ import (
 )
 
 var siPrefixTable = map[float64]string{
+	-30: "q", // quecto
+	-27: "r", // ronto
 	-24: "y", // yocto
 	-21: "z", // zepto
 	-18: "a", // atto
@@ -25,6 +27,8 @@ var siPrefixTable = map[float64]string{
 	18:  "E", // exa
 	21:  "Z", // zetta
 	24:  "Y", // yotta
+	27:  "R", // ronna
+	30:  "Q", // quetta
 }
 
 var revSIPrefixTable = revfmap(siPrefixTable)

--- a/si_test.go
+++ b/si_test.go
@@ -11,6 +11,8 @@ func TestSI(t *testing.T) {
 		num       float64
 		formatted string
 	}{
+		{"e-30", 1e-30, "1 qF"},
+		{"e-27", 1e-27, "1 rF"},
 		{"e-24", 1e-24, "1 yF"},
 		{"e-21", 1e-21, "1 zF"},
 		{"e-18", 1e-18, "1 aF"},
@@ -54,6 +56,8 @@ func TestSI(t *testing.T) {
 		{"e+18", 2.2e+18, "2.2 EF"},
 		{"e+21", 2.2e+21, "2.2 ZF"},
 		{"e+24", 2.2e+24, "2.2 YF"},
+		{"e+27", 2.2e+27, "2.2 RF"},
+		{"e+30", 2.2e+30, "2.2 QF"},
 
 		// special case
 		{"1F", 1000 * 1000, "1 MF"},


### PR DESCRIPTION
In 2022, a couple of new prefixes became available in SI and IEC standards: ronto (10⁻²⁷), quecto (10⁻³⁰), ronna (10²⁷), quetta (10³⁰).

https://www.bipm.org/documents/20126/64811223/Resolutions-2022.pdf/281f3160-fc56-3e63-dbf7-77b76500990f

Here’s the pull request adding them to `SI` and `BigBytes` humanizers.