### PR TITLE
Set github workflow permissions to read only

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -9,6 +9,9 @@ on:
   pull_request:
     branches: [ "master" ]
 
+permissions:
+  contents: read
+
 jobs:
 
   build:


### PR DESCRIPTION
Closes #109 

## Changes

- set go.yml top level permission to `contents: read``
- tested the workflow at https://github.com/joycebrum/go-humanize/actions/runs/4285734355