### PR TITLE
Enable dependency update tool

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,14 @@
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# Please see the documentation for all configuration options:
+# https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+
+version: 2
+updates:
+  - package-ecosystem: "github-actions" # Necessary to update action hashes	
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    # Allow up to 2 opened pull requests for github-actions versions
+    open-pull-requests-limit: 2
+

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,8 +1,3 @@
-# To get started with Dependabot version updates, you'll need to specify which
-# package ecosystems to update and where the package manifests are located.
-# Please see the documentation for all configuration options:
-# https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
-
 version: 2
 updates:
   - package-ecosystem: "github-actions" # Necessary to update action hashes	


### PR DESCRIPTION
Hi @dustin, still regarding #114, it is possible to enable a dependency update tool. The most famous ones are [Dependabot](https://github.blog/2020-06-01-keep-all-your-packages-up-to-date-with-dependabot/) and [Renovatebot](https://www.mend.io/renovate/).

Both have pros and cons and I can help you in the comparison at "Additional Context" if you want to know more about them. Here in the PR I brought a configuration file for dependabot (since it is official GitHub tool, it is easier to configure). I try to keep it with big week limitations to not bother you on maintaining the project. Here is a dependabot PR example https://github.com/joycebrum/go-humanize/pull/1.

PS: the idea is to use both tools to update github workflow dependencies, but if you with it can be used to update other dependencies in the project (see [possible package ecosystems for dependabot](https://docs.github.com/pt/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#package-ecosystem) for example).
 
Let me know if you rather use renovatebot, I can configure it for you.

### Additional Context

#### Dependabot
Pros
- GitHub Official Tool
- Does not break yml-lint “2 spaces before # comment inline” rule when updating
- Easy to configure

Cons
- It produces one PR for each version upgrade (more noise)


#### Renovatebot
Pros
- It can be configured to hash pin automatically new dependencies.
- It can group dependency upgrades in one single PR (example https://github.com/diogoteles08/testing-dependabot/issues/13)

Cons
- Third Party 
- More complex configuration
- Breaks yml-lint “2 spaces before # comment inline” rule when updating (https://github.com/adrienverge/yamllint/issues/443)