### PR TITLE
Minor markdown formatting fix

### DIFF
--- a/number.go
+++ b/number.go
@@ -42,6 +42,7 @@ var (
 )
 
 // FormatFloat produces a formatted number as string based on the following user-specified criteria:
+//
 // * thousands separator
 // * decimal separator
 // * decimal precision


### PR DESCRIPTION
So that https://pkg.go.dev/github.com/dustin/go-humanize#FormatFloat renders it correctly