### PR TITLE
Allow to specify minimum number of digits for bytes

### DIFF
--- a/bytes.go
+++ b/bytes.go
@@ -65,18 +65,29 @@ func logn(n, b float64) float64 {
 	return math.Log(n) / math.Log(b)
 }
 
-func humanateBytes(s uint64, base float64, sizes []string) string {
+func countDigits(n int64) int {
+	digits := 0
+	for n != 0 {
+		n /= 10
+		digits += 1
+	}
+	return digits
+}
+
+func humanateBytes(s uint64, base float64, minDigits int, sizes []string) string {
 	if s < 10 {
 		return fmt.Sprintf("%d B", s)
 	}
 	e := math.Floor(logn(float64(s), base))
 	suffix := sizes[int(e)]
-	val := math.Floor(float64(s)/math.Pow(base, e)*10+0.5) / 10
-	f := "%.0f %s"
-	if val < 10 {
-		f = "%.1f %s"
+	rounding := math.Pow10(minDigits - 1)
+	val := math.Floor(float64(s)/math.Pow(base, e)*rounding+0.5) / rounding
+	ff := "%%.%df %%s"
+	digits := minDigits - countDigits(int64(val))
+	if digits < 0 {
+		digits = 0
 	}
-
+	f := fmt.Sprintf(ff, digits)
 	return fmt.Sprintf(f, val, suffix)
 }
 
@@ -87,7 +98,17 @@ func humanateBytes(s uint64, base float64, sizes []string) string {
 // Bytes(82854982) -> 83 MB
 func Bytes(s uint64) string {
 	sizes := []string{"B", "kB", "MB", "GB", "TB", "PB", "EB"}
-	return humanateBytes(s, 1000, sizes)
+	return humanateBytes(s, 1000, 2, sizes)
+}
+
+// BytesN produces a human readable representation of an SI size, with at least the specified number of digits.
+//
+// See also: ParseBytes.
+//
+// BytesN(82854982, 3) -> 82.9 MB
+func BytesN(s uint64, n int) string {
+	sizes := []string{"B", "kB", "MB", "GB", "TB", "PB", "EB"}
+	return humanateBytes(s, 1000, n, sizes)
 }
 
 // IBytes produces a human readable representation of an IEC size.
@@ -97,7 +118,17 @@ func Bytes(s uint64) string {
 // IBytes(82854982) -> 79 MiB
 func IBytes(s uint64) string {
 	sizes := []string{"B", "KiB", "MiB", "GiB", "TiB", "PiB", "EiB"}
-	return humanateBytes(s, 1024, sizes)
+	return humanateBytes(s, 1024, 2, sizes)
+}
+
+// IBytesN produces a human readable representation of an IEC size.
+//
+// See also: ParseBytes.
+//
+// IBytesN(82854982, 4) -> 79.02 MiB
+func IBytesN(s uint64, n int) string {
+	sizes := []string{"B", "KiB", "MiB", "GiB", "TiB", "PiB", "EiB"}
+	return humanateBytes(s, 1024, n, sizes)
 }
 
 // ParseBytes parses a string representation of bytes into the number

--- a/bytes.go
+++ b/bytes.go
@@ -91,7 +91,7 @@ func humanateBytes(s uint64, base float64, minDigits int, sizes []string) string
 	return fmt.Sprintf(f, val, suffix)
 }
 
-// Bytes produces a human readable representation of an SI size.
+// Bytes produces a human-readable representation of an SI size.
 //
 // See also: ParseBytes.
 //
@@ -101,17 +101,20 @@ func Bytes(s uint64) string {
 	return humanateBytes(s, 1000, 2, sizes)
 }
 
-// BytesN produces a human readable representation of an SI size, with at least the specified number of digits.
+// BytesN produces a human-readable representation of an SI size.
+// n specifies the total number of digits to output, including the decimal part.
+// If n is less than or equal to the number of digits in the integer part, the decimal part will be omitted.
 //
 // See also: ParseBytes.
 //
 // BytesN(82854982, 3) -> 82.9 MB
+// BytesN(82854982, 4) -> 82.85 MB
 func BytesN(s uint64, n int) string {
 	sizes := []string{"B", "kB", "MB", "GB", "TB", "PB", "EB"}
 	return humanateBytes(s, 1000, n, sizes)
 }
 
-// IBytes produces a human readable representation of an IEC size.
+// IBytes produces a human-readable representation of an IEC size.
 //
 // See also: ParseBytes.
 //
@@ -121,11 +124,15 @@ func IBytes(s uint64) string {
 	return humanateBytes(s, 1024, 2, sizes)
 }
 
-// IBytesN produces a human readable representation of an IEC size.
+// IBytesN produces a human-readable representation of an IEC size.
+// n specifies the total number of digits to output, including the decimal part.
+// If n is less than or equal to the number of digits in the integer part, the decimal part will be omitted.
 //
 // See also: ParseBytes.
 //
-// IBytesN(82854982, 4) -> 79.02 MiB
+// IBytesN(82854982, 4)  -> 79.02 MiB
+// IBytesN(123456789, 3) -> 118 MiB
+// IBytesN(123456789, 6) -> 117.738 MiB
 func IBytesN(s uint64, n int) string {
 	sizes := []string{"B", "KiB", "MiB", "GiB", "TiB", "PiB", "EiB"}
 	return humanateBytes(s, 1024, n, sizes)

--- a/bytes_test.go
+++ b/bytes_test.go
@@ -103,6 +103,8 @@ func TestBytes(t *testing.T) {
 		// Overflows.
 		// {"bytes(1EB - 1P)", Bytes((KByte*EByte)-PByte), "1023EB"},
 
+		{"bytesN(1234, 3)", BytesN(1234, 3), "1.23 kB"},
+
 		{"bytes(0)", IBytes(0), "0 B"},
 		{"bytes(1)", IBytes(1), "1 B"},
 		{"bytes(803)", IBytes(803), "803 B"},
@@ -130,6 +132,9 @@ func TestBytes(t *testing.T) {
 		{"bytes(5.5GiB)", IBytes(5.5 * GiByte), "5.5 GiB"},
 
 		{"bytes(5.5GB)", Bytes(5.5 * GByte), "5.5 GB"},
+
+		{"bytes(123456789, 3)", IBytesN(123456789, 3), "118 MiB"},
+		{"bytes(123456789, 6)", IBytesN(123456789, 6), "117.738 MiB"},
 	}.validate(t)
 }
 


### PR DESCRIPTION
Currently, `humanateBytes` returns at least 2 digits, so for values below 10, it returns one decimal, otherwise none. It would be nice to be able to customize this, for example to print two decimals for values below 10, or still print a decimal on values below 100.

This PR introduces the `BytesN` and `IBytesN` functions, which allow specifying a minimum number of digits, so decimals + integer part digits.