### PR TITLE
Fixing issues #103 and #127 with bytes and bigbytes

### DIFF
--- a/bigbytes_test.go
+++ b/bigbytes_test.go
@@ -88,19 +88,19 @@ func TestBigBytes(t *testing.T) {
 		{"bytes(999)", bbyte(999), "999 B"},
 
 		{"bytes(1024)", bbyte(1024), "1.0 kB"},
-		{"bytes(1MB - 1)", bbyte(MByte - Byte), "1000 kB"},
+		{"bytes(1MB - 1)", bbyte(MByte - Byte), "1.0 MB"},
 
 		{"bytes(1MB)", bbyte(1024 * 1024), "1.0 MB"},
-		{"bytes(1GB - 1K)", bbyte(GByte - KByte), "1000 MB"},
+		{"bytes(1GB - 1K)", bbyte(GByte - KByte), "1.0 GB"},
 
 		{"bytes(1GB)", bbyte(GByte), "1.0 GB"},
-		{"bytes(1TB - 1M)", bbyte(TByte - MByte), "1000 GB"},
+		{"bytes(1TB - 1M)", bbyte(TByte - MByte), "1.0 TB"},
 
 		{"bytes(1TB)", bbyte(TByte), "1.0 TB"},
 		{"bytes(1PB - 1T)", bbyte(PByte - TByte), "999 TB"},
 
 		{"bytes(1PB)", bbyte(PByte), "1.0 PB"},
-		{"bytes(1PB - 1T)", bbyte(EByte - PByte), "999 PB"},
+		{"bytes(1EB - 1P)", bbyte(EByte - PByte), "999 PB"},
 
 		{"bytes(1EB)", bbyte(EByte), "1.0 EB"},
 		// Overflows.
@@ -112,19 +112,19 @@ func TestBigBytes(t *testing.T) {
 		{"bytes(1023)", bibyte(1023), "1023 B"},
 
 		{"bytes(1024)", bibyte(1024), "1.0 KiB"},
-		{"bytes(1MB - 1)", bibyte(MiByte - IByte), "1024 KiB"},
+		{"bytes(1MiB - 1)", bibyte(MiByte - IByte), "1.0 MiB"},
 
-		{"bytes(1MB)", bibyte(1024 * 1024), "1.0 MiB"},
-		{"bytes(1GB - 1K)", bibyte(GiByte - KiByte), "1024 MiB"},
+		{"bytes(1MiB)", bibyte(1024 * 1024), "1.0 MiB"},
+		{"bytes(1GiB - 1Ki)", bibyte(GiByte - KiByte), "1.0 GiB"},
 
-		{"bytes(1GB)", bibyte(GiByte), "1.0 GiB"},
-		{"bytes(1TB - 1M)", bibyte(TiByte - MiByte), "1024 GiB"},
+		{"bytes(1GiB)", bibyte(GiByte), "1.0 GiB"},
+		{"bytes(1TiB - 1Mi)", bibyte(TiByte - MiByte), "1.0 TiB"},
 
-		{"bytes(1TB)", bibyte(TiByte), "1.0 TiB"},
-		{"bytes(1PB - 1T)", bibyte(PiByte - TiByte), "1023 TiB"},
+		{"bytes(1TiB)", bibyte(TiByte), "1.0 TiB"},
+		{"bytes(1PiB - 1Ti)", bibyte(PiByte - TiByte), "1023 TiB"},
 
-		{"bytes(1PB)", bibyte(PiByte), "1.0 PiB"},
-		{"bytes(1PB - 1T)", bibyte(EiByte - PiByte), "1023 PiB"},
+		{"bytes(1PiB)", bibyte(PiByte), "1.0 PiB"},
+		{"bytes(1EiB - 1Pi)", bibyte(EiByte - PiByte), "1023 PiB"},
 
 		{"bytes(1EiB)", bibyte(EiByte), "1.0 EiB"},
 		// Overflows.
@@ -133,6 +133,8 @@ func TestBigBytes(t *testing.T) {
 		{"bytes(5.5GiB)", bibyte(5.5 * GiByte), "5.5 GiB"},
 
 		{"bytes(5.5GB)", bbyte(5.5 * GByte), "5.5 GB"},
+
+		{"bytes(31450000)", bbyte(31450000), "31 MB"},
 	}.validate(t)
 }
 

--- a/bytes.go
+++ b/bytes.go
@@ -66,18 +66,38 @@ func logn(n, b float64) float64 {
 }
 
 func humanateBytes(s uint64, base float64, sizes []string) string {
-	if s < 10 {
-		return fmt.Sprintf("%d B", s)
+	if s < uint64(base) {
+		return strconv.FormatUint(s, 10) + " B"
 	}
 	e := math.Floor(logn(float64(s), base))
-	suffix := sizes[int(e)]
-	val := math.Floor(float64(s)/math.Pow(base, e)*10+0.5) / 10
-	f := "%.0f %s"
-	if val < 10 {
-		f = "%.1f %s"
+
+	val := float64(s) / math.Pow(base, e)
+
+	fmt.Println(val)
+	// round preserving at least 2 significant digits and without
+	// producing a value FormatFloat/Sprintf would round up
+	if val >= 10 {
+		val = math.Floor(val + 0.5)
+	} else {
+		val = math.Floor(val*10+0.5) / 10
 	}
 
-	return fmt.Sprintf(f, val, suffix)
+	// avoid numbers like 1000 KB instead of 1.0 MB
+	if val >= base {
+		e++
+		val = 1
+	}
+	suffix := sizes[int(e)]
+
+	// format: one decimal if <10, otherwise no decimals
+	var num string
+	if val < 10 {
+		num = strconv.FormatFloat(val, 'f', 1, 64)
+	} else {
+		num = strconv.FormatFloat(val, 'f', 0, 64)
+	}
+
+	return num + " " + suffix
 }
 
 // Bytes produces a human readable representation of an SI size.

--- a/bytes_test.go
+++ b/bytes_test.go
@@ -84,24 +84,24 @@ func TestBytes(t *testing.T) {
 
 		{"bytes(1024)", Bytes(1024), "1.0 kB"},
 		{"bytes(9999)", Bytes(9999), "10 kB"},
-		{"bytes(1MB - 1)", Bytes(MByte - Byte), "1000 kB"},
+		{"bytes(1MB - 1)", Bytes(MByte - Byte), "1.0 MB"},
 
 		{"bytes(1MB)", Bytes(1024 * 1024), "1.0 MB"},
-		{"bytes(1GB - 1K)", Bytes(GByte - KByte), "1000 MB"},
+		{"bytes(1GB - 1K)", Bytes(GByte - KByte), "1.0 GB"},
 
 		{"bytes(1GB)", Bytes(GByte), "1.0 GB"},
-		{"bytes(1TB - 1M)", Bytes(TByte - MByte), "1000 GB"},
+		{"bytes(1TB - 1M)", Bytes(TByte - MByte), "1.0 TB"},
 		{"bytes(10MB)", Bytes(9999 * 1000), "10 MB"},
 
 		{"bytes(1TB)", Bytes(TByte), "1.0 TB"},
 		{"bytes(1PB - 1T)", Bytes(PByte - TByte), "999 TB"},
 
 		{"bytes(1PB)", Bytes(PByte), "1.0 PB"},
-		{"bytes(1PB - 1T)", Bytes(EByte - PByte), "999 PB"},
+		{"bytes(1EB - 1P)", Bytes(EByte - PByte), "999 PB"},
 
 		{"bytes(1EB)", Bytes(EByte), "1.0 EB"},
 		// Overflows.
-		// {"bytes(1EB - 1P)", Bytes((KByte*EByte)-PByte), "1023EB"},
+		// {"bytes(1024EB - 1P)", Bytes((KByte*EByte)-PByte), "1023EB"},
 
 		{"bytes(0)", IBytes(0), "0 B"},
 		{"bytes(1)", IBytes(1), "1 B"},
@@ -109,27 +109,29 @@ func TestBytes(t *testing.T) {
 		{"bytes(1023)", IBytes(1023), "1023 B"},
 
 		{"bytes(1024)", IBytes(1024), "1.0 KiB"},
-		{"bytes(1MB - 1)", IBytes(MiByte - IByte), "1024 KiB"},
+		{"bytes(1MiB - 1)", IBytes(MiByte - IByte), "1.0 MiB"},
 
-		{"bytes(1MB)", IBytes(1024 * 1024), "1.0 MiB"},
-		{"bytes(1GB - 1K)", IBytes(GiByte - KiByte), "1024 MiB"},
+		{"bytes(1MiB)", IBytes(1024 * 1024), "1.0 MiB"},
+		{"bytes(1GiB - 1K)", IBytes(GiByte - KiByte), "1.0 GiB"},
 
-		{"bytes(1GB)", IBytes(GiByte), "1.0 GiB"},
-		{"bytes(1TB - 1M)", IBytes(TiByte - MiByte), "1024 GiB"},
+		{"bytes(1GiB)", IBytes(GiByte), "1.0 GiB"},
+		{"bytes(1TiB - 1M)", IBytes(TiByte - MiByte), "1.0 TiB"},
 
-		{"bytes(1TB)", IBytes(TiByte), "1.0 TiB"},
-		{"bytes(1PB - 1T)", IBytes(PiByte - TiByte), "1023 TiB"},
+		{"bytes(1TiB)", IBytes(TiByte), "1.0 TiB"},
+		{"bytes(1PiB - 1T)", IBytes(PiByte - TiByte), "1023 TiB"},
 
-		{"bytes(1PB)", IBytes(PiByte), "1.0 PiB"},
-		{"bytes(1PB - 1T)", IBytes(EiByte - PiByte), "1023 PiB"},
+		{"bytes(1PiB)", IBytes(PiByte), "1.0 PiB"},
+		{"bytes(1EiB - 1P)", IBytes(EiByte - PiByte), "1023 PiB"},
 
 		{"bytes(1EiB)", IBytes(EiByte), "1.0 EiB"},
 		// Overflows.
-		// {"bytes(1EB - 1P)", IBytes((KIByte*EIByte)-PiByte), "1023EB"},
+		// {"bytes(1024EB - 1P)", IBytes((KIByte*EIByte)-PiByte), "1023EB"},
 
 		{"bytes(5.5GiB)", IBytes(5.5 * GiByte), "5.5 GiB"},
 
 		{"bytes(5.5GB)", Bytes(5.5 * GByte), "5.5 GB"},
+
+		{"bytes(31450000)", Bytes(31450000), "31 MB"},
 	}.validate(t)
 }
 


### PR DESCRIPTION
- #103 double rounding edge case returns wrong value
- #127 outputting 1000 kB instead of 1.0 MB for some values
- unit tests updated and/or added for above fixes

Fix also speeds up the float and int formatting so that after adding extra logic to fix edge cases, humanateBytes and humanateBigBytes are faster than they were before.

### More details on #103 fix
Here is what the code did with the specific issue reported with humanizing 31450000

1. Calculate that this should be 31.45 MB
2. Multiply 31.45 by 10 and add 0.5 -> 315.0
3. Floor of 315.0 then divide by 10 -> 31.5
4. Tell Sprintf to format 31.5 with no decimals -> Sprintf rounds to 32
5. Return "32 MB" instead of expected "31 MB"

Fix now rounds differently depending on if value being rounded is >= 10 or <10 so that after rounding, Sprintf won't round again.
