### PR TITLE
feat: add ParseComma and ParseCommaf

### DIFF
--- a/comma.go
+++ b/comma.go
@@ -129,3 +129,19 @@ func BigComma(bin *big.Int) string {
 	parts[j] = strconv.Itoa(int(b.Int64()))
 	return sign + strings.Join(parts[j:], ",")
 }
+
+// ParseComma parses a string produced by Comma.
+// It strips commas and returns the int64 value, or an error if the
+// string cannot be parsed.
+func ParseComma(s string) (int64, error) {
+	s = strings.ReplaceAll(s, ",", "")
+	return strconv.ParseInt(s, 10, 64)
+}
+
+// ParseCommaf parses a string produced by Commaf.
+// It strips commas and returns the float64 value, or an error if the
+// string cannot be parsed.
+func ParseCommaf(s string) (float64, error) {
+	s = strings.ReplaceAll(s, ",", "")
+	return strconv.ParseFloat(s, 64)
+}

--- a/comma_test.go
+++ b/comma_test.go
@@ -154,3 +154,132 @@ func TestHumanizeBigIntMutation(t *testing.T) {
 		t.Fail()
 	}
 }
+
+func TestParseComma(t *testing.T) {
+	tests := []struct {
+		in  string
+		exp int64
+	}{
+		{"0", 0},
+		{"10", 10},
+		{"1,000", 1000},
+		{"123,456,789", 123456789},
+		{"-10", -10},
+		{"-1,000", -1000},
+		{"-123,456,789", -123456789},
+		{"-9,223,372,036,854,775,808", math.MinInt64},
+		{"9,223,372,036,854,775,807", math.MaxInt64},
+	}
+
+	for _, p := range tests {
+		got, err := ParseComma(p.in)
+		if err != nil {
+			t.Errorf("Couldn't parse %v: %v", p.in, err)
+		}
+		if got != p.exp {
+			t.Errorf("Expected %v for %v, got %v", p.exp, p.in, got)
+		}
+	}
+
+	roundTripTests := []int64{
+		0,
+		123456789,
+		-123456789,
+		math.MaxInt64,
+		math.MinInt64,
+	}
+
+	for _, n := range roundTripTests {
+		got, err := ParseComma(Comma(n))
+		if err != nil {
+			t.Errorf("Round-trip failed for %v: %v", n, err)
+		}
+		if got != n {
+			t.Errorf("Round-trip failed: expected %v, got %v", n, got)
+		}
+	}
+}
+
+func TestParseCommaErrors(t *testing.T) {
+	errorTests := []string{
+		"",
+		"abc",
+		"123a456",
+		"1.5",
+	}
+
+	for _, s := range errorTests {
+		got, err := ParseComma(s)
+		if err == nil {
+			t.Errorf("Expected error for %q, got %v", s, got)
+		}
+		if got != 0 {
+			t.Errorf("Expected 0 on error for %q, got %v", s, got)
+		}
+	}
+}
+
+func TestParseCommaf(t *testing.T) {
+	tests := []struct {
+		in  string
+		exp float64
+	}{
+		{"0", 0},
+		{"10", 10},
+		{"1,000", 1000},
+		{"123,456,789", 123456789},
+		{"10.11", 10.11},
+		{"834,142.32", 834142.32},
+		{"-10", -10},
+		{"-1,000", -1000},
+		{"-100.11", -100.11},
+		{"-123,456,789.123", -123456789.123},
+	}
+
+	for _, p := range tests {
+		got, err := ParseCommaf(p.in)
+		if err != nil {
+			t.Errorf("Couldn't parse %v: %v", p.in, err)
+		}
+		if math.Abs(got-p.exp) > math.Abs(p.exp)*1e-9 {
+			t.Errorf("Expected %v for %v, got %v", p.exp, p.in, got)
+		}
+	}
+
+	roundTripTests := []float64{
+		0,
+		123456789,
+		123456789.123,
+		-123456789,
+		-123456789.123,
+	}
+
+	for _, f := range roundTripTests {
+		got, err := ParseCommaf(Commaf(f))
+		if err != nil {
+			t.Errorf("Round-trip failed for %v: %v", f, err)
+		}
+		if math.Abs(got-f) > math.Abs(f)*1e-9 {
+			t.Errorf("Round-trip failed: expected %v, got %v", f, got)
+		}
+	}
+}
+
+func TestParseCommafErrors(t *testing.T) {
+	errorTests := []string{
+		"",
+		"abc",
+		"123a456",
+		"1.2.3",
+	}
+
+	for _, s := range errorTests {
+		got, err := ParseCommaf(s)
+		if err == nil {
+			t.Errorf("Expected error for %q, got %v", s, got)
+		}
+		if got != 0 {
+			t.Errorf("Expected 0 on error for %q, got %v", s, got)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

- Add `ParseComma(s string) (int64, error)` — inverse of `Comma()`, strips commas and parses as int64
- Add `ParseCommaf(s string) (float64, error)` — inverse of `Commaf()`, strips commas and parses as float64
- Both functions round-trip correctly: `ParseComma(Comma(n)) == n` and `ParseCommaf(Commaf(f)) ≈ f`

## Test plan

- [x] `TestParseComma`: positive, negative, zero, `MinInt64`, `MaxInt64`, round-trip assertions
- [x] `TestParseCommaErrors`: empty string, non-numeric, float string
- [x] `TestParseCommaf`: positive/negative floats with decimals, round-trip with epsilon comparison (`1e-9`)
- [x] `TestParseCommafErrors`: empty string, non-numeric, multi-dot string

🤖 Generated with [Claude Code](https://claude.com/claude-code)