### PR TITLE
feat: add CommafWithPrecision for fixed-precision float formatting

### DIFF
--- a/comma.go
+++ b/comma.go
@@ -98,6 +98,50 @@ func CommafWithDigits(f float64, decimals int) string {
 	return stripTrailingDigits(Commaf(f), decimals)
 }
 
+// CommafWithPrecision formats a float64 number with thousands separators and
+// the specified number of decimal places. It aligns with the behavior
+// of strconv.FormatFloat with 'f' format.
+//
+// - Integer part gets comma separators every three digits
+// - Decimal part retains exactly 'digits' places
+// - When digits = 0, no decimal point is output
+// - Negative numbers have the minus sign at the front
+//
+// e.g. CommafWithPrecision(1234567.89, 2) -> "1,234,567.89"
+//
+//	CommafWithPrecision(-1234.5, 0) -> "-1,234"
+func CommafWithPrecision(num float64, digits int) string {
+	buf := &bytes.Buffer{}
+	if num < 0 {
+		buf.Write([]byte{'-'})
+		num = 0 - num
+	}
+
+	formatted := strconv.FormatFloat(num, 'f', digits, 64)
+	parts := strings.Split(formatted, ".")
+
+	comma := []byte{','}
+
+	pos := 0
+	if len(parts[0])%3 != 0 {
+		pos += len(parts[0]) % 3
+		buf.WriteString(parts[0][:pos])
+		buf.Write(comma)
+	}
+	for ; pos < len(parts[0]); pos += 3 {
+		buf.WriteString(parts[0][pos : pos+3])
+		buf.Write(comma)
+	}
+	buf.Truncate(buf.Len() - 1)
+
+	if len(parts) > 1 {
+		buf.Write([]byte{'.'})
+		buf.WriteString(parts[1])
+	}
+
+	return buf.String()
+}
+
 // BigComma produces a string form of the given big.Int in base 10
 // with commas after every three orders of magnitude.
 func BigComma(bin *big.Int) string {

--- a/comma.go
+++ b/comma.go
@@ -129,3 +129,19 @@ func BigComma(bin *big.Int) string {
 	parts[j] = strconv.Itoa(int(b.Int64()))
 	return sign + strings.Join(parts[j:], ",")
 }
+
+// ParseComma parses a string produced by Comma.
+// It strips commas and returns the int64 value, or an error if the
+// string cannot be parsed.
+func ParseComma(s string) (int64, error) {
+	s = strings.ReplaceAll(s, ",", "")
+	return strconv.ParseInt(s, 10, 64)
+}
+
+// ParseCommaf parses a string produced by Commaf.
+// It strips commas and returns the float64 value, or an error if the
+// string cannot be parsed.
+func ParseCommaf(s string) (float64, error) {
+	s = strings.ReplaceAll(s, ",", "")
+	return strconv.ParseFloat(s, 64)
+}

--- a/comma_test.go
+++ b/comma_test.go
@@ -154,3 +154,132 @@ func TestHumanizeBigIntMutation(t *testing.T) {
 		t.Fail()
 	}
 }
+
+func TestParseComma(t *testing.T) {
+	tests := []struct {
+		in  string
+		exp int64
+	}{
+		{"0", 0},
+		{"10", 10},
+		{"1,000", 1000},
+		{"123,456,789", 123456789},
+		{"-10", -10},
+		{"-1,000", -1000},
+		{"-123,456,789", -123456789},
+		{"-9,223,372,036,854,775,808", math.MinInt64},
+		{"9,223,372,036,854,775,807", math.MaxInt64},
+	}
+
+	for _, p := range tests {
+		got, err := ParseComma(p.in)
+		if err != nil {
+			t.Errorf("Couldn't parse %v: %v", p.in, err)
+		}
+		if got != p.exp {
+			t.Errorf("Expected %v for %v, got %v", p.exp, p.in, got)
+		}
+	}
+
+	roundTripTests := []int64{
+		0,
+		123456789,
+		-123456789,
+		math.MaxInt64,
+		math.MinInt64,
+	}
+
+	for _, n := range roundTripTests {
+		got, err := ParseComma(Comma(n))
+		if err != nil {
+			t.Errorf("Round-trip failed for %v: %v", n, err)
+		}
+		if got != n {
+			t.Errorf("Round-trip failed: expected %v, got %v", n, got)
+		}
+	}
+}
+
+func TestParseCommaErrors(t *testing.T) {
+	errorTests := []string{
+		"",
+		"abc",
+		"123a456",
+		"1.5",
+	}
+
+	for _, s := range errorTests {
+		got, err := ParseComma(s)
+		if err == nil {
+			t.Errorf("Expected error for %q, got %v", s, got)
+		}
+		if got != 0 {
+			t.Errorf("Expected 0 on error for %q, got %v", s, got)
+		}
+	}
+}
+
+func TestParseCommaf(t *testing.T) {
+	tests := []struct {
+		in  string
+		exp float64
+	}{
+		{"0", 0},
+		{"10", 10},
+		{"1,000", 1000},
+		{"123,456,789", 123456789},
+		{"10.11", 10.11},
+		{"834,142.32", 834142.32},
+		{"-10", -10},
+		{"-1,000", -1000},
+		{"-100.11", -100.11},
+		{"-123,456,789.123", -123456789.123},
+	}
+
+	for _, p := range tests {
+		got, err := ParseCommaf(p.in)
+		if err != nil {
+			t.Errorf("Couldn't parse %v: %v", p.in, err)
+		}
+		if math.Abs(got-p.exp) > math.Abs(p.exp)*1e-9 {
+			t.Errorf("Expected %v for %v, got %v", p.exp, p.in, got)
+		}
+	}
+
+	roundTripTests := []float64{
+		0,
+		123456789,
+		123456789.123,
+		-123456789,
+		-123456789.123,
+	}
+
+	for _, f := range roundTripTests {
+		got, err := ParseCommaf(Commaf(f))
+		if err != nil {
+			t.Errorf("Round-trip failed for %v: %v", f, err)
+		}
+		if math.Abs(got-f) > math.Abs(f)*1e-9 {
+			t.Errorf("Round-trip failed: expected %v, got %v", f, got)
+		}
+	}
+}
+
+func TestParseCommafErrors(t *testing.T) {
+	errorTests := []string{
+		"",
+		"abc",
+		"123a456",
+		"1.2.3",
+	}
+
+	for _, s := range errorTests {
+		got, err := ParseCommaf(s)
+		if err == nil {
+			t.Errorf("Expected error for %q, got %v", s, got)
+		}
+		if got != 0 {
+			t.Errorf("Expected 0 on error for %q, got %v", s, got)
+		}
+	}
+}

--- a/commaf_test.go
+++ b/commaf_test.go
@@ -43,3 +43,21 @@ func TestBigCommafs(t *testing.T) {
 		{"-10", BigCommaf(big.NewFloat(-10)), "-10"},
 	}.validate(t)
 }
+
+func TestCommafWithPrecision(t *testing.T) {
+	testList{
+		{"positive, digits=2", CommafWithPrecision(1234567.89, 2), "1,234,567.89"},
+		{"negative, digits=2", CommafWithPrecision(-1234567.89, 2), "-1,234,567.89"},
+		{"zero, digits=2", CommafWithPrecision(0, 2), "0.00"},
+		{"positive, digits=0", CommafWithPrecision(1234.56, 0), "1,235"},
+		{"negative, digits=0", CommafWithPrecision(-1234.56, 0), "-1,235"},
+		{"zero, digits=0", CommafWithPrecision(0, 0), "0"},
+		{"positive, digits=4", CommafWithPrecision(123.456789, 4), "123.4568"},
+		{"negative, digits=4", CommafWithPrecision(-123.456789, 4), "-123.4568"},
+		{"zero, digits=4", CommafWithPrecision(0, 4), "0.0000"},
+		{"small positive, digits=2", CommafWithPrecision(1.23, 2), "1.23"},
+		{"large positive, digits=2", CommafWithPrecision(1234567890.12, 2), "1,234,567,890.12"},
+		{"small negative, digits=2", CommafWithPrecision(-1.23, 2), "-1.23"},
+		{"large negative, digits=2", CommafWithPrecision(-1234567890.12, 2), "-1,234,567,890.12"},
+	}.validate(t)
+}


### PR DESCRIPTION
## Summary

Adds `CommafWithPrecision(num float64, digits int) string` — a convenience wrapper that combines thousands-separator formatting with fixed decimal precision.

`FormatFloat` already exists in `number.go` with signature `func FormatFloat(format string, n float64) string` (pattern-string based), so a new name is used to avoid a naming conflict.

```go
CommafWithPrecision(1234567.89, 2)   // "1,234,567.89"
CommafWithPrecision(-9876543.0, 0)   // "-9,876,543"
CommafWithPrecision(0, 4)            // "0.0000"
```

Internally delegates to `strconv.FormatFloat(num, 'f', digits, 64)` for rounding (consistent with stdlib), then applies the same comma-insertion loop used by `Commaf` and `CommafWithDigits`.

## Tests

Added `TestCommafWithPrecision` in `commaf_test.go` covering positive, negative, zero, `digits=0`, `digits=2`, and `digits=4`. All existing tests continue to pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)