### PR TITLE
fix: move FormatFloatComma to commaf.go and guard NaN/Inf inputs

### DIFF
--- a/comma.go
+++ b/comma.go
@@ -98,6 +98,50 @@ func CommafWithDigits(f float64, decimals int) string {
 	return stripTrailingDigits(Commaf(f), decimals)
 }
 
+// CommafWithPrecision formats a float64 number with thousands separators and
+// the specified number of decimal places. It aligns with the behavior
+// of strconv.FormatFloat with 'f' format.
+//
+// - Integer part gets comma separators every three digits
+// - Decimal part retains exactly 'digits' places
+// - When digits = 0, no decimal point is output
+// - Negative numbers have the minus sign at the front
+//
+// e.g. CommafWithPrecision(1234567.89, 2) -> "1,234,567.89"
+//
+//	CommafWithPrecision(-1234.5, 0) -> "-1,234"
+func CommafWithPrecision(num float64, digits int) string {
+	buf := &bytes.Buffer{}
+	if num < 0 {
+		buf.Write([]byte{'-'})
+		num = 0 - num
+	}
+
+	formatted := strconv.FormatFloat(num, 'f', digits, 64)
+	parts := strings.Split(formatted, ".")
+
+	comma := []byte{','}
+
+	pos := 0
+	if len(parts[0])%3 != 0 {
+		pos += len(parts[0]) % 3
+		buf.WriteString(parts[0][:pos])
+		buf.Write(comma)
+	}
+	for ; pos < len(parts[0]); pos += 3 {
+		buf.WriteString(parts[0][pos : pos+3])
+		buf.Write(comma)
+	}
+	buf.Truncate(buf.Len() - 1)
+
+	if len(parts) > 1 {
+		buf.Write([]byte{'.'})
+		buf.WriteString(parts[1])
+	}
+
+	return buf.String()
+}
+
 // BigComma produces a string form of the given big.Int in base 10
 // with commas after every three orders of magnitude.
 func BigComma(bin *big.Int) string {

--- a/comma.go
+++ b/comma.go
@@ -98,58 +98,6 @@ func CommafWithDigits(f float64, decimals int) string {
 	return stripTrailingDigits(Commaf(f), decimals)
 }
 
-// FormatFloatComma formats a float64 number with thousands separators and
-// the specified number of decimal places. It aligns with the behavior
-// of strconv.FormatFloat with 'f' format.
-//
-// Key differences from CommafWithDigits:
-//   - FormatFloatComma uses strconv.FormatFloat, which rounds the decimal
-//     part to the specified number of digits (half-to-even rounding)
-//   - CommafWithDigits simply truncates the decimal part without rounding
-//
-// - Integer part gets comma separators every three digits
-// - Decimal part retains exactly 'digits' places (with rounding)
-// - When digits = 0, no decimal point is output
-// - Negative numbers have the minus sign at the front
-//
-// e.g. FormatFloatComma(1234.5678, 2) -> "1,234.57" (rounded)
-//
-//	CommafWithDigits(1234.5678, 2)    -> "1,234.56" (truncated)
-//
-//	FormatFloatComma(1234567.89, 2) -> "1,234,567.89"
-//	FormatFloatComma(-1234.5, 0)     -> "-1,234"
-func FormatFloatComma(num float64, digits int) string {
-	buf := &bytes.Buffer{}
-	if num < 0 {
-		buf.Write([]byte{'-'})
-		num = 0 - num
-	}
-
-	formatted := strconv.FormatFloat(num, 'f', digits, 64)
-	parts := strings.Split(formatted, ".")
-
-	comma := []byte{','}
-
-	pos := 0
-	if len(parts[0])%3 != 0 {
-		pos += len(parts[0]) % 3
-		buf.WriteString(parts[0][:pos])
-		buf.Write(comma)
-	}
-	for ; pos < len(parts[0]); pos += 3 {
-		buf.WriteString(parts[0][pos : pos+3])
-		buf.Write(comma)
-	}
-	buf.Truncate(buf.Len() - 1)
-
-	if len(parts) > 1 {
-		buf.Write([]byte{'.'})
-		buf.WriteString(parts[1])
-	}
-
-	return buf.String()
-}
-
 // BigComma produces a string form of the given big.Int in base 10
 // with commas after every three orders of magnitude.
 func BigComma(bin *big.Int) string {

--- a/comma.go
+++ b/comma.go
@@ -129,3 +129,19 @@ func BigComma(bin *big.Int) string {
 	parts[j] = strconv.Itoa(int(b.Int64()))
 	return sign + strings.Join(parts[j:], ",")
 }
+
+// ParseComma parses a string produced by Comma.
+// It strips commas and returns the int64 value, or an error if the
+// string cannot be parsed.
+func ParseComma(s string) (int64, error) {
+	s = strings.ReplaceAll(s, ",", "")
+	return strconv.ParseInt(s, 10, 64)
+}
+
+// ParseCommaf parses a string produced by Commaf.
+// It strips commas and returns the float64 value, or an error if the
+// string cannot be parsed.
+func ParseCommaf(s string) (float64, error) {
+	s = strings.ReplaceAll(s, ",", "")
+	return strconv.ParseFloat(s, 64)
+}

--- a/comma.go
+++ b/comma.go
@@ -98,19 +98,27 @@ func CommafWithDigits(f float64, decimals int) string {
 	return stripTrailingDigits(Commaf(f), decimals)
 }
 
-// CommafWithPrecision formats a float64 number with thousands separators and
+// FormatFloatComma formats a float64 number with thousands separators and
 // the specified number of decimal places. It aligns with the behavior
 // of strconv.FormatFloat with 'f' format.
 //
+// Key differences from CommafWithDigits:
+//   - FormatFloatComma uses strconv.FormatFloat, which rounds the decimal
+//     part to the specified number of digits (half-to-even rounding)
+//   - CommafWithDigits simply truncates the decimal part without rounding
+//
 // - Integer part gets comma separators every three digits
-// - Decimal part retains exactly 'digits' places
+// - Decimal part retains exactly 'digits' places (with rounding)
 // - When digits = 0, no decimal point is output
 // - Negative numbers have the minus sign at the front
 //
-// e.g. CommafWithPrecision(1234567.89, 2) -> "1,234,567.89"
+// e.g. FormatFloatComma(1234.5678, 2) -> "1,234.57" (rounded)
 //
-//	CommafWithPrecision(-1234.5, 0) -> "-1,234"
-func CommafWithPrecision(num float64, digits int) string {
+//	CommafWithDigits(1234.5678, 2)    -> "1,234.56" (truncated)
+//
+//	FormatFloatComma(1234567.89, 2) -> "1,234,567.89"
+//	FormatFloatComma(-1234.5, 0)     -> "-1,234"
+func FormatFloatComma(num float64, digits int) string {
 	buf := &bytes.Buffer{}
 	if num < 0 {
 		buf.Write([]byte{'-'})

--- a/comma_test.go
+++ b/comma_test.go
@@ -154,3 +154,132 @@ func TestHumanizeBigIntMutation(t *testing.T) {
 		t.Fail()
 	}
 }
+
+func TestParseComma(t *testing.T) {
+	tests := []struct {
+		in  string
+		exp int64
+	}{
+		{"0", 0},
+		{"10", 10},
+		{"1,000", 1000},
+		{"123,456,789", 123456789},
+		{"-10", -10},
+		{"-1,000", -1000},
+		{"-123,456,789", -123456789},
+		{"-9,223,372,036,854,775,808", math.MinInt64},
+		{"9,223,372,036,854,775,807", math.MaxInt64},
+	}
+
+	for _, p := range tests {
+		got, err := ParseComma(p.in)
+		if err != nil {
+			t.Errorf("Couldn't parse %v: %v", p.in, err)
+		}
+		if got != p.exp {
+			t.Errorf("Expected %v for %v, got %v", p.exp, p.in, got)
+		}
+	}
+
+	roundTripTests := []int64{
+		0,
+		123456789,
+		-123456789,
+		math.MaxInt64,
+		math.MinInt64,
+	}
+
+	for _, n := range roundTripTests {
+		got, err := ParseComma(Comma(n))
+		if err != nil {
+			t.Errorf("Round-trip failed for %v: %v", n, err)
+		}
+		if got != n {
+			t.Errorf("Round-trip failed: expected %v, got %v", n, got)
+		}
+	}
+}
+
+func TestParseCommaErrors(t *testing.T) {
+	errorTests := []string{
+		"",
+		"abc",
+		"123a456",
+		"1.5",
+	}
+
+	for _, s := range errorTests {
+		got, err := ParseComma(s)
+		if err == nil {
+			t.Errorf("Expected error for %q, got %v", s, got)
+		}
+		if got != 0 {
+			t.Errorf("Expected 0 on error for %q, got %v", s, got)
+		}
+	}
+}
+
+func TestParseCommaf(t *testing.T) {
+	tests := []struct {
+		in  string
+		exp float64
+	}{
+		{"0", 0},
+		{"10", 10},
+		{"1,000", 1000},
+		{"123,456,789", 123456789},
+		{"10.11", 10.11},
+		{"834,142.32", 834142.32},
+		{"-10", -10},
+		{"-1,000", -1000},
+		{"-100.11", -100.11},
+		{"-123,456,789.123", -123456789.123},
+	}
+
+	for _, p := range tests {
+		got, err := ParseCommaf(p.in)
+		if err != nil {
+			t.Errorf("Couldn't parse %v: %v", p.in, err)
+		}
+		if math.Abs(got-p.exp) > math.Abs(p.exp)*1e-9 {
+			t.Errorf("Expected %v for %v, got %v", p.exp, p.in, got)
+		}
+	}
+
+	roundTripTests := []float64{
+		0,
+		123456789,
+		123456789.123,
+		-123456789,
+		-123456789.123,
+	}
+
+	for _, f := range roundTripTests {
+		got, err := ParseCommaf(Commaf(f))
+		if err != nil {
+			t.Errorf("Round-trip failed for %v: %v", f, err)
+		}
+		if math.Abs(got-f) > math.Abs(f)*1e-9 {
+			t.Errorf("Round-trip failed: expected %v, got %v", f, got)
+		}
+	}
+}
+
+func TestParseCommafErrors(t *testing.T) {
+	errorTests := []string{
+		"",
+		"abc",
+		"123a456",
+		"1.2.3",
+	}
+
+	for _, s := range errorTests {
+		got, err := ParseCommaf(s)
+		if err == nil {
+			t.Errorf("Expected error for %q, got %v", s, got)
+		}
+		if got != 0 {
+			t.Errorf("Expected 0 on error for %q, got %v", s, got)
+		}
+	}
+}

--- a/commaf.go
+++ b/commaf.go
@@ -5,7 +5,9 @@ package humanize
 
 import (
 	"bytes"
+	"math"
 	"math/big"
+	"strconv"
 	"strings"
 )
 
@@ -37,5 +39,73 @@ func BigCommaf(v *big.Float) string {
 		buf.Write([]byte{'.'})
 		buf.WriteString(parts[1])
 	}
+	return buf.String()
+}
+
+// FormatFloatComma formats a float64 number with thousands separators and
+// the specified number of decimal places. It aligns with the behavior
+// of strconv.FormatFloat with 'f' format.
+//
+// Key differences from CommafWithDigits:
+//   - FormatFloatComma uses strconv.FormatFloat, which rounds the decimal
+//     part to the specified number of digits (half-to-even rounding)
+//   - CommafWithDigits simply truncates the decimal part without rounding
+//
+// Special floating-point values (NaN, +Inf, -Inf) are returned as-is without
+// thousands separator processing.
+//
+// - Integer part gets comma separators every three digits
+// - Decimal part retains exactly 'digits' places (with rounding)
+// - When digits = 0, no decimal point is output
+// - Negative numbers have the minus sign at the front
+//
+// e.g. FormatFloatComma(1234.5678, 2) -> "1,234.57" (rounded)
+//
+//	CommafWithDigits(1234.5678, 2)    -> "1,234.56" (truncated)
+//
+//	FormatFloatComma(1234567.89, 2) -> "1,234,567.89"
+//	FormatFloatComma(-1234.5, 0)     -> "-1,234"
+//	FormatFloatComma(math.NaN(), 2)   -> "NaN"
+//	FormatFloatComma(math.Inf(1), 2)  -> "+Inf"
+//	FormatFloatComma(math.Inf(-1), 2) -> "-Inf"
+func FormatFloatComma(num float64, digits int) string {
+	if math.IsNaN(num) {
+		return "NaN"
+	}
+	if math.IsInf(num, 1) {
+		return "+Inf"
+	}
+	if math.IsInf(num, -1) {
+		return "-Inf"
+	}
+
+	buf := &bytes.Buffer{}
+	if num < 0 {
+		buf.Write([]byte{'-'})
+		num = 0 - num
+	}
+
+	formatted := strconv.FormatFloat(num, 'f', digits, 64)
+	parts := strings.Split(formatted, ".")
+
+	comma := []byte{','}
+
+	pos := 0
+	if len(parts[0])%3 != 0 {
+		pos += len(parts[0]) % 3
+		buf.WriteString(parts[0][:pos])
+		buf.Write(comma)
+	}
+	for ; pos < len(parts[0]); pos += 3 {
+		buf.WriteString(parts[0][pos : pos+3])
+		buf.Write(comma)
+	}
+	buf.Truncate(buf.Len() - 1)
+
+	if len(parts) > 1 {
+		buf.Write([]byte{'.'})
+		buf.WriteString(parts[1])
+	}
+
 	return buf.String()
 }

--- a/commaf_test.go
+++ b/commaf_test.go
@@ -61,5 +61,8 @@ func TestFormatFloatComma(t *testing.T) {
 		{"large negative, digits=2", FormatFloatComma(-1234567890.12, 2), "-1,234,567,890.12"},
 		{"rounding vs truncation: FormatFloatComma rounds", FormatFloatComma(1234.5678, 2), "1,234.57"},
 		{"rounding vs truncation: CommafWithDigits truncates", CommafWithDigits(1234.5678, 2), "1,234.56"},
+		{"NaN", FormatFloatComma(math.NaN(), 2), "NaN"},
+		{"+Inf", FormatFloatComma(math.Inf(1), 2), "+Inf"},
+		{"-Inf", FormatFloatComma(math.Inf(-1), 2), "-Inf"},
 	}.validate(t)
 }

--- a/commaf_test.go
+++ b/commaf_test.go
@@ -44,20 +44,22 @@ func TestBigCommafs(t *testing.T) {
 	}.validate(t)
 }
 
-func TestCommafWithPrecision(t *testing.T) {
+func TestFormatFloatComma(t *testing.T) {
 	testList{
-		{"positive, digits=2", CommafWithPrecision(1234567.89, 2), "1,234,567.89"},
-		{"negative, digits=2", CommafWithPrecision(-1234567.89, 2), "-1,234,567.89"},
-		{"zero, digits=2", CommafWithPrecision(0, 2), "0.00"},
-		{"positive, digits=0", CommafWithPrecision(1234.56, 0), "1,235"},
-		{"negative, digits=0", CommafWithPrecision(-1234.56, 0), "-1,235"},
-		{"zero, digits=0", CommafWithPrecision(0, 0), "0"},
-		{"positive, digits=4", CommafWithPrecision(123.456789, 4), "123.4568"},
-		{"negative, digits=4", CommafWithPrecision(-123.456789, 4), "-123.4568"},
-		{"zero, digits=4", CommafWithPrecision(0, 4), "0.0000"},
-		{"small positive, digits=2", CommafWithPrecision(1.23, 2), "1.23"},
-		{"large positive, digits=2", CommafWithPrecision(1234567890.12, 2), "1,234,567,890.12"},
-		{"small negative, digits=2", CommafWithPrecision(-1.23, 2), "-1.23"},
-		{"large negative, digits=2", CommafWithPrecision(-1234567890.12, 2), "-1,234,567,890.12"},
+		{"positive, digits=2", FormatFloatComma(1234567.89, 2), "1,234,567.89"},
+		{"negative, digits=2", FormatFloatComma(-1234567.89, 2), "-1,234,567.89"},
+		{"zero, digits=2", FormatFloatComma(0, 2), "0.00"},
+		{"positive, digits=0", FormatFloatComma(1234.56, 0), "1,235"},
+		{"negative, digits=0", FormatFloatComma(-1234.56, 0), "-1,235"},
+		{"zero, digits=0", FormatFloatComma(0, 0), "0"},
+		{"positive, digits=4", FormatFloatComma(123.456789, 4), "123.4568"},
+		{"negative, digits=4", FormatFloatComma(-123.456789, 4), "-123.4568"},
+		{"zero, digits=4", FormatFloatComma(0, 4), "0.0000"},
+		{"small positive, digits=2", FormatFloatComma(1.23, 2), "1.23"},
+		{"large positive, digits=2", FormatFloatComma(1234567890.12, 2), "1,234,567,890.12"},
+		{"small negative, digits=2", FormatFloatComma(-1.23, 2), "-1.23"},
+		{"large negative, digits=2", FormatFloatComma(-1234567890.12, 2), "-1,234,567,890.12"},
+		{"rounding vs truncation: FormatFloatComma rounds", FormatFloatComma(1234.5678, 2), "1,234.57"},
+		{"rounding vs truncation: CommafWithDigits truncates", CommafWithDigits(1234.5678, 2), "1,234.56"},
 	}.validate(t)
 }

--- a/commaf_test.go
+++ b/commaf_test.go
@@ -43,3 +43,21 @@ func TestBigCommafs(t *testing.T) {
 		{"-10", BigCommaf(big.NewFloat(-10)), "-10"},
 	}.validate(t)
 }
+
+func TestCommafWithPrecision(t *testing.T) {
+	testList{
+		{"positive, digits=2", CommafWithPrecision(1234567.89, 2), "1,234,567.89"},
+		{"negative, digits=2", CommafWithPrecision(-1234567.89, 2), "-1,234,567.89"},
+		{"zero, digits=2", CommafWithPrecision(0, 2), "0.00"},
+		{"positive, digits=0", CommafWithPrecision(1234.56, 0), "1,235"},
+		{"negative, digits=0", CommafWithPrecision(-1234.56, 0), "-1,235"},
+		{"zero, digits=0", CommafWithPrecision(0, 0), "0"},
+		{"positive, digits=4", CommafWithPrecision(123.456789, 4), "123.4568"},
+		{"negative, digits=4", CommafWithPrecision(-123.456789, 4), "-123.4568"},
+		{"zero, digits=4", CommafWithPrecision(0, 4), "0.0000"},
+		{"small positive, digits=2", CommafWithPrecision(1.23, 2), "1.23"},
+		{"large positive, digits=2", CommafWithPrecision(1234567890.12, 2), "1,234,567,890.12"},
+		{"small negative, digits=2", CommafWithPrecision(-1.23, 2), "-1.23"},
+		{"large negative, digits=2", CommafWithPrecision(-1234567890.12, 2), "-1,234,567,890.12"},
+	}.validate(t)
+}


### PR DESCRIPTION
## Summary

Two correctness issues found in the previous implementation:

### 1. Wrong file placement

`FormatFloatComma` is a float formatter and belongs in `commaf.go` alongside `Commaf`, `CommafWithDigits`, and `BigCommaf` — not in `comma.go` which only contains integer comma helpers. Migrated accordingly.

### 2. Unguarded special float values

`strconv.FormatFloat` on `NaN` / `±Inf` produces the strings `"NaN"` / `"+Inf"` / `"-Inf"`. Without an early-return guard these strings would enter the comma-insertion loop and produce garbled output. Added `math.IsNaN` and `math.IsInf` checks that short-circuit before the loop:

```go
if math.IsNaN(num) { return "NaN" }
if math.IsInf(num,  1) { return "+Inf" }
if math.IsInf(num, -1) { return "-Inf" }
```

### Tests added

```go
{"NaN",  FormatFloatComma(math.NaN(),    2), "NaN"}
{"+Inf", FormatFloatComma(math.Inf(1),   2), "+Inf"}
{"-Inf", FormatFloatComma(math.Inf(-1),  2), "-Inf"}
```

All existing tests continue to pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)